### PR TITLE
Do not require presence of downloadURL in dataHierarchy field to list file

### DIFF
--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -307,11 +307,14 @@ createDataHierarchy(){
         // this.fileHierarchy = this.createTreeObj("Files","Files");
         // this.fileHierarchy.children =[];
          for(let fields of this.recordDisplay['dataHierarchy']){
-                if( fields.downloadURL != null)
-                    this.files.push(this.createFileNode(fields.filepath, fields.filepath));
-                else 
+                if( fields.filepath != null) {
                     if(fields.children != null)
-                      this.files.push(this.createChildrenTree(fields.children,fields.filepath));       
+                        this.files.push(this.createChildrenTree(fields.children,
+                                                               fields.filepath));
+                    else
+                        this.files.push(this.createFileNode(fields.filepath,
+                                                            fields.filepath));
+                }
             }
         
         //this.files.push(this.fileHierarchy);

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -327,13 +327,13 @@ createDataHierarchy(){
     for(let child of children){
         let fname = child.filepath.split("/")[child.filepath.split("/").length-1]
 
-        if( fields.filepath != null) {
-            if(fields.children != null)
-                this.files.push(this.createChildrenTree(fields.children,
-                                                        fields.filepath));
+        if( child.filepath != null) {
+            if(child.children != null)
+                testObj.children.push(this.createChildrenTree(child.children,
+                                                              child.filepath));
             else
-                this.files.push(this.createFileNode(fields.filepath,
-                                                    fields.filepath));
+                testObj.children.push(this.createFileNode(child.filepath,
+                                                          child.filepath));
         }
      }
      return testObj;

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -326,12 +326,15 @@ createDataHierarchy(){
     //console.log(children);
     for(let child of children){
         let fname = child.filepath.split("/")[child.filepath.split("/").length-1]
-        
-         if(child.downloadURL != null){
-              testObj.children.push(this.createFileNode(fname, child.filepath));
-         }else if(child.children != null){
-           testObj.children.push(this.createChildrenTree(child.children,child.filepath));
-         }
+
+        if( fields.filepath != null) {
+            if(fields.children != null)
+                this.files.push(this.createChildrenTree(fields.children,
+                                                        fields.filepath));
+            else
+                this.files.push(this.createFileNode(fields.filepath,
+                                                    fields.filepath));
+        }
      }
      return testObj;
   }


### PR DESCRIPTION
[ODD-446](http://mml.nist.gov:8080/browse/ODD-446) primarily concerns a bug in [oar-pdr](https://github.com/usnistgov/oar-pdr)'s metadata server that was failing to update the `dataHierarchy` field in NERDm records created from MIDAS pod records.  As part of this, I also removed the inclusion on the `downloadURL` in the `dataHierarchy` structure, as (we believed) it was no longer be used to display the hierarchy.  There turns out to be a remnant of its use in the landing page-generated code in oar-sdp which prevents the listing of files from the "fixed" metadata server.   This PR removes this reliance on the `downloadURL` inside the `dataHierarchy` structure and allows the file hierarchy to be displayed correctly.  