### PR TITLE
API button url incorrect for oardev

### DIFF
--- a/src/client/sdp/api/api.component.css
+++ b/src/client/sdp/api/api.component.css
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  }
+}
 
 h2 {
   font-size: 20px;
@@ -11,12 +11,12 @@ h2 {
 }
 
 .background-white {
-	background-color:#ffffff;
+  background-color:#ffffff;
 }
 
 .center
 {
-	align: center;
+  align: center;
 }
 
 .divPad
@@ -24,8 +24,26 @@ h2 {
   padding: 50px 100px 50px 100px;
 }
 
-
 .cardDiv:hover{
   color: #1471AE;
   border:1px solid;
 }
+
+.api:hover
+{
+  background-color: #808080;
+  color: #fff;
+}
+
+.api
+{
+  background-color:#595959;
+  color: #fff;
+}
+
+.element {
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}
+

--- a/src/client/sdp/api/api.component.html
+++ b/src/client/sdp/api/api.component.html
@@ -22,15 +22,14 @@
     </ol>
   </div>
 </div>
-
 <div class="card">
   <div class="ui-g">
     <div class="ui-g-12">
-      <div class="ui-g-12 ui-md-6 ui-lg-6">
-       <p> This NIST Data Discovery web portal hosts access to a RestFul web service public API, Application Programming
-        Interface.  This API provides our developer community the capability to dynamically query the underlying data
-        resource catalog, a collection of key NIST research dataset descriptions (metadata).
-       </p>
+      <div class="ui-g-12 ui-md-8 ui-lg-8">
+        <p> This NIST Data Discovery web portal hosts access to a RestFul web service public API, Application Programming
+          Interface.  This API provides our developer community the capability to dynamically query the underlying data
+          resource catalog, a collection of key NIST research dataset descriptions (metadata).
+        </p>
         <p>
           The search API returns JSON open-standard format data objects containing high level resource information and scientific domain specific metadata representations.   We are in the process of extending these results as our data holdings increase in NIST’s Public Data Repository
           system to further capabilities in scientific data discovery and mining of NIST research public data sets.
@@ -38,11 +37,9 @@
       </div>
       <div class="ui-g-12 ui-md-6 ui-lg-1">
       </div>
-      <div class="ui-g-12 ui-md-6 ui-lg-4">
-        <a  href = "{{RestAPIURL}}swagger-ui.html" target="_blank" >
-        <img class="Fleft" srcset="./assets/images/API.png" alt="API" style="height: 70%;width: 70%;margin-top: 15px" >
-      </a>
+      <div class="ui-g-12 ui-md-4 ui-lg-2 element" >
+        <a class="btn btn-primary btn-lg api " href = "{{RestAPIURL}}swagger-ui.html" target="_blank" >Explore Data Discovery API</a>
       </div>
+    </div>
   </div>
-</div>
 </div>

--- a/src/client/sdp/api/api.component.ts
+++ b/src/client/sdp/api/api.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Config } from '../shared/index';
+import { environment } from '../environment';
 
 
 /**
@@ -13,6 +13,6 @@ import { Config } from '../shared/index';
 })
 export class ApiComponent {
 
-  RestAPIURL: string = Config.RMMAPI;
+  RestAPIURL: string = environment.RMMAPI;
 
 }


### PR DESCRIPTION
Fixed -
1.Clicking on the Data Discovery button under the API tab incorrectly goes to https://localhost/rmm/swagger-ui.html instead of the oardev/rmm....
2.Change text to "Explore Data Discovery API". Text background color should change when hover over