### PR TITLE
ODD-516: show only file basenames in file listing

### DIFF
--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -333,7 +333,7 @@ createMenuItem(label :string, icon:string, command: any, url : string ){
                     testObj.children.push(this.createChildrenTree(child.children,
                                                                   child.filepath));
                 else
-                    testObj.children.push(this.createFileNode(child.filepath,
+                    testObj.children.push(this.createFileNode(fname,
                                                               child.filepath));
             }
          }


### PR DESCRIPTION
This PR addresses issue [ODD-516](http://mml.nist.gov:8080/browse/ODD-516) that calls for the landing page file listing to only display base filenames without the preceding paths.  