### PR TITLE
search box has a (small) character limit

### DIFF
--- a/src/client/sdp/adv_search/adv_search.component.html
+++ b/src/client/sdp/adv_search/adv_search.component.html
@@ -41,7 +41,7 @@
           <div class="inner-addon left-addon element " style="background-color: #FFFFFF" [hidden]="textRotate" >
             <i class="glyphicon glyphicon-search"></i><label for="searchinput" class="hideLabel">Search Input</label>
             <p-autoComplete inputId="searchinput"  [inputStyle]="{'width': '100%','padding-left':'40px','height': '42px','font-weight': '400',
-        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue"  (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "30" [size] = "50" >
+        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue"  (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
           </p-autoComplete>
           </div>
         </div>

--- a/src/client/sdp/home/home.component.html
+++ b/src/client/sdp/home/home.component.html
@@ -38,7 +38,7 @@
           <label for="searchinput" class="hideLabel">Search Input</label>
           <div class="inner-addon left-addon element " style="background-color: #FFFFFF" [hidden]="textRotate" >
             <i class="glyphicon glyphicon-search"></i>  <p-autoComplete [inputStyle]="{'width': '100%','padding-left':'40px','height': '42px','font-weight': '400',
-        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue" inputId="searchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "30" [size] = "50" >
+        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue" inputId="searchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
           </p-autoComplete>
           </div>
         </div>

--- a/src/client/sdp/search/search.component.html
+++ b/src/client/sdp/search/search.component.html
@@ -27,7 +27,7 @@
         <div class="ui-g-12 ui-md-4" style="padding-right: 0px;padding-left: 0px;padding-bottom: 0px">
           <div class="inner-addon left-addon element " style="background-color: #FFFFFF" >
             <i class="glyphicon glyphicon-search"></i><label for="searchinput" class="hideLabel">Search Input</label><p-autoComplete [inputStyle]="{'width': '100%','padding-left':'40px','height': '42px','font-weight': '400',
-        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue"  inputId="searchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "30" [size] = "50" >
+        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue"  inputId="searchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
           </p-autoComplete>
           </div>
         </div>


### PR DESCRIPTION
The SDP search box apparently allows one to enter only 30 characters.
If a limit is required, this should be set to something fairly large
(e.g. 2048).