### PR TITLE
Fix SDP banner

### DIFF
--- a/src/client/sdp/app.searchtopbar.component.ts
+++ b/src/client/sdp/app.searchtopbar.component.ts
@@ -6,11 +6,11 @@ import { AppComponent } from './app.component';
     template: `
     <div class="topbar" style="background-color: #000000">
       <span class="topbar-left" style="background-color: #000000;">
-          <a href="/" title="National Institute of Standards and Technology" class="header__logo-link" rel="home">
+          <a href="/" style="text-decoration: none" title="National Institute of Standards and Technology" class="header__logo-link" rel="home">
           <img class="Fleft" srcset="./assets/images/nist_logo_reverse.png" 
           alt="National Institute of Standards and Technology" title="National Institute of Standards and Technology" >
-            </a> 
-        <span style="color: #FFFFFF;font-size: large;padding-left: 2%">Science <br> &nbsp;Data Portal </span>
+            <span class="Fleft" style="line-height: 16.5px;display: table-cell;vertical-align: text-top;color: #FFFFFF;font-size:16px;padding-left: 2%">Science <br> Data Portal </span>
+          </a>
       </span>
       <span class="badge" style="background-color:#982800;vertical-align: text-top;margin-top: 20px;">1.0.0-beta</span>
         <div class="topbar-right">


### PR DESCRIPTION
user expects to go to home by clicking region of “NIST Science Data
Portal” logo in upper left, but the map is not drawn correctly and only
works in a small part of this region
Align Logo and Science data portal