### PR TITLE
fix previous erroneous conflict resolution: restore download all link

### DIFF
--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -190,12 +190,12 @@ export class LandingPanelComponent implements OnInit, OnDestroy {
       if(!_.includes(this.landing, "rmm"))
         this.serviceApi = this.landing+this.recordDisplay['ediid'];
 
-      //this.distdownload = this.distApi+"ds/zip?id="+this.recordDisplay['@id'];
-      this.distdownload = this.distApi+"/"+this.recordDisplay['@id']+"?format=zip";
+      this.distdownload = this.distApi+"ds/zip?id="+this.recordDisplay['@id'];
+      //this.distdownload = this.distApi+"/"+this.recordDisplay['@id']+"?format=zip";
       
       var itemsMenu: any[] = [];
       var homepage = this.createMenuItem("Visit Home Page",  "faa faa-external-link", '',this.recordDisplay['landingPage']);
-      var download = this.createMenuItem("Download all data","faa faa-download", '', this.distdownload);
+      var download = this.createMenuItem("Download all data","faa faa-file-archive-o", '', this.distdownload);
       var metadata = this.createMenuItem("Export JSON", "faa faa-file-o",'',this.serviceApi);
     
         itemsMenu.push(homepage);


### PR DESCRIPTION
While resolving conflicts as part of #149, a few patches related to downloading all files from a landing page got lost.  In particular, after the merge of #149:
* The icon next to the "Download All Data" link on the right menu got changed back to the download icon, where it should have been a archive icon.
* The link associated with download all was changed to a form inconsistent with the distribution service.

This PR fixes these errors.  The icon is now the archive icon, and the link is corrected to the `/zip?id=ark/...` form.