### PR TITLE
ODD-552: Race condition in SDP end-to-end tests

### DIFF
--- a/src/client/sdp/search/search.component.html
+++ b/src/client/sdp/search/search.component.html
@@ -320,8 +320,8 @@
                   <div class="ui-grid-col-12">
                     <div class="ui-grid ui-grid-responsive" style="text-align: left;width: auto;">
                       <div class="ui-grid-row">
-                        <div class="ui-grid-col-12" ><b><a href="{{PDRAPIURL}}{{resultItem.ediid}}" target="_blank" class="title" >
-                          {{resultItem.title}}</a></b></div>
+                        <div class="ui-grid-col-12" ><h4><b><a href="{{PDRAPIURL}}{{resultItem.ediid}}" target="_blank" class="title" >
+                          {{resultItem.title}}</a></b></h4></div>
                       </div>
                       <div class="ui-grid-row" *ngIf = "selectedFields.indexOf('Resource Description') !==-1">
                         <read-more [text]="resultItem.description" [maxLength]="270" ></read-more>

--- a/src/e2e/specs/sdp/about/about.component.e2e-spec.ts
+++ b/src/e2e/specs/sdp/about/about.component.e2e-spec.ts
@@ -6,9 +6,9 @@ describe('About Page', function() {
   });
 
   it('should display title of about page', async() => {
-    browser.sleep(5000);
-    var label = await element(by.css('sdp-about label'));
-    expect(label.getText()).toContain('About NIST Data');
+    browser.sleep(2000);
+    var label = await element(by.css('sdp-about label')).getText();
+    expect(label).toEqual('About NIST Data');
   });
 
 });

--- a/src/e2e/specs/sdp/adv_search/adv_search.component.e2e-spec.ts
+++ b/src/e2e/specs/sdp/adv_search/adv_search.component.e2e-spec.ts
@@ -6,7 +6,7 @@ describe('Advanced Search Page', function() {
   });
 
   it('should display title of advanced search page', async() => {
-
+    browser.sleep(1000);
     var label = element.all(by.css('sdp-advsearch label'));
     expect(label.get(0).getText()).toContain('Advanced Search Builder');
   });

--- a/src/e2e/specs/sdp/api/api.component.e2e-spec.ts
+++ b/src/e2e/specs/sdp/api/api.component.e2e-spec.ts
@@ -6,9 +6,9 @@ describe('API Page', function() {
   });
 
   it('should display title of api page', async() => {
-
-    var label = await element(by.css('sdp-api label'));
-    expect(label.getText()).toContain('APIs');
+    browser.sleep(1000);
+    var label = await element(by.css('sdp-api label')).getText();
+    expect(label).toEqual('APIs');
   });
 
 });

--- a/src/e2e/specs/sdp/app.component.e2e-spec.ts
+++ b/src/e2e/specs/sdp/app.component.e2e-spec.ts
@@ -9,6 +9,7 @@ describe('App', () => {
   });
 
   it('should have a title', async () => {
+    browser.sleep(1000);
     const title = await browser.getTitle();
     expect(title).toEqual('NIST Data Repository Page');
   });

--- a/src/e2e/specs/sdp/faq/faq.component.e2e-spec.ts
+++ b/src/e2e/specs/sdp/faq/faq.component.e2e-spec.ts
@@ -6,9 +6,9 @@ describe('FAQ Page', function() {
   });
 
   it('should display title of faq page', async() => {
-
-    var label = await element(by.css('sdp-faq label'));
-    expect(label.getText()).toContain('FAQ');
+    browser.sleep(1000);
+    var label = await element(by.css('sdp-faq label')).getText();
+    expect(label).toEqual('FAQ');
   });
 
 });

--- a/src/e2e/specs/sdp/help/help.component.e2e-spec.ts
+++ b/src/e2e/specs/sdp/help/help.component.e2e-spec.ts
@@ -6,9 +6,9 @@ describe('Help Page', function() {
   });
 
   it('should display title of help page', async() => {
-
-    var label = await element(by.css('sdp-help label'));
-    expect(label.getText()).toContain('Help');
+    browser.sleep(1000);
+    var label = await element(by.css('sdp-help label')).getText();
+    expect(label).toEqual('Help');
   });
 
 });

--- a/src/e2e/specs/sdp/policy/policy.component.e2e-spec.ts
+++ b/src/e2e/specs/sdp/policy/policy.component.e2e-spec.ts
@@ -6,9 +6,9 @@ describe('Policy Page', function() {
   });
 
   it('should display title of policy page', async() => {
-
-    var label = await element(by.css('sdp-policy label'));
-    expect(label.getText()).toContain('Policy');
+    browser.sleep(1000);
+    var label = await element(by.css('sdp-policy label')).getText();
+    expect(label).toEqual('Policy');
   });
 
 });

--- a/src/e2e/specs/sdp/search/search.component.e2e-spec.ts
+++ b/src/e2e/specs/sdp/search/search.component.e2e-spec.ts
@@ -7,7 +7,7 @@ describe('Search Results Page', function() {
   });
 
   it('should display top title of Search page', async() => {
-    //var EC = protractor.ExpectedConditions;
+    browser.sleep(1000);
     const text = await element(by.css('sdp-search h4')).getText();
     expect(text).toContain("SRD 69");
   });


### PR DESCRIPTION
ODD 552 - 
http://mml.nist.gov:8080/browse/ODD-552
Issue:
One or more of the oar-sdp end-to-end (e2e) tests for the sdp app often
fail with an error message:NoSuchElementError: No element found using
locator: By(css selector, sdp-about label)

Fix:
Added 1 second delay to all the end-end scripts so that page is completely loaded. For About page, I have added 2 second delay as scripts are getting failed with 1 second delay.
