### PR TITLE
Fix/odd 590 references on landingpage

### DIFF
--- a/src/client/pdr/landing/description.component.ts
+++ b/src/client/pdr/landing/description.component.ts
@@ -28,16 +28,31 @@ import { TreeModule,TreeNode, Tree, MenuItem } from 'primeng/primeng';
             </div>
             <br>
             <div *ngIf="checkReferences()">
-             <h3 id="reference" name="reference">References</h3>
-               This data is discussed in :
-                <span *ngFor="let refs of record['references']">
-                  <span *ngIf="refs['refType'] == 'IsDocumentedBy'">
-                    <br> <a href={{refs.location}} target="blank">{{ refs.label }}</a>
-                  </span>
+             <h3 id="reference" name="reference"><b>References:</b></h3>
+                <span *ngIf="isDocumentedBy"> 
+                    This data is discussed in :
+                    <span style="padding-left:2.75em" *ngFor="let refs of record['references']">
+                        <span *ngIf="refs['refType'] == 'IsDocumentedBy'">
+                            <br> <i class="faa faa-external-link">
+                                 <a href={{refs.location}} target="blank">{{ refs.label }}</a>
+                                 </i>
+                        </span>
+                    </span>
+                    <br>
+                </span>
+                <span *ngIf="isReferencedBy"> 
+                    This data is referenced in :
+                    <span style="padding-left:2.75em" *ngFor="let refs of record['references']">
+                        <span *ngIf="refs['refType'] == 'IsReferencedBy'">
+                            <br> <i class="faa faa-external-link">
+                            <a href={{refs.location}} target="blank">{{ refs.location }}</a>
+                            </i>
+                        </span>
+                    </span>
                 </span>
             </div>
             <div>
-
+            <br>
              <h3><b>Access To Data:</b></h3><br> 
              <span *ngIf="record['accessLevel'] === 'public'"><i class="faa faa-globe"></i> 
                 This data is public. 
@@ -107,6 +122,8 @@ export class DescriptionComponent {
  accessPages: Map <string, string> = new Map();
  accessUrls : string[] =[];
  accessTitles : string[] =[];
+ isReferencedBy : boolean = false;
+ isDocumentedBy : boolean = false;
  
 
  nodeSelect(event) {
@@ -130,11 +147,15 @@ keys() : Array<string> {
 
 checkReferences(){
       if(Array.isArray(this.record['references']) ){
-          for(let ref of this.record['references'] ){
-              if(ref.refType === 'isDocumentedBy') return true;
-          }
+        for(let ref of this.record['references'] ){
+            if(ref.refType === 'IsDocumentedBy') this.isDocumentedBy = true;
+            if(ref.refType === 'IsReferencedBy') this.isReferencedBy = true;
+        }
+        if(this.isDocumentedBy || this.isReferencedBy)
+        return true;
       }
  }
+
 
  checkKeywords(){
     if(Array.isArray(this.record['keyword']) ){

--- a/src/client/pdr/landing/landing.component.html
+++ b/src/client/pdr/landing/landing.component.html
@@ -90,11 +90,13 @@
                         <span>Identifier: </span>
                         <span *ngIf="isDOI" ><i>  <a href="http://doi.org/{{recordDisplay.doi.split(':')[1]}}">{{recordDisplay.doi}}</a></i></span>
                         <span  *ngIf="!isDOI"><i> <a href="{{pdrApi}}{{recordDisplay['@id']}}">{{recordDisplay["@id"]}}</a></i> </span>
-                        <span *ngIf="checkReferences()">
+                        <span *ngIf="checkReferences()"><br>
                         <span>Described in article: </span>
-                            <small *ngFor="let refs of recordDisplay.references; let i =index">
-                                <span *ngIf="refs.refType == 'IsDocumentedBy'">
-                                    <br><a href={{refs.location}} target="blank" >{{ refs.label }}</a>
+                            <small *ngFor="let refs of recordDisplay['references']; let i =index">
+                               
+                                <span style="padding-left:2.75em" *ngIf="refs.refType == 'IsDocumentedBy'">
+                                    <br><i class="faa faa-external-link">
+                                    <a href={{refs.location}} target="blank" >{{ refs.label }}</a></i>
                                 <span *ngIf="i < recordDisplay.references.length-1 ">,</span>
                                 </span>
                             </small>

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -407,7 +407,7 @@ export class LandingPanelComponent implements OnInit, OnDestroy {
   checkReferences(){
     if(Array.isArray(this.recordDisplay['references']) ){
       for(let ref of this.recordDisplay['references'] ){
-        if(ref.refType == "isDocumentedBy") return true;
+        if(ref.refType == "IsDocumentedBy") return true;
       }
     }
   }


### PR DESCRIPTION
This is with reference to the bug reported [ODD-590](http://mml.nist.gov:8080/browse/ODD-590)
Issue was, landing page was not displaying references properly. This was because we restricted the references by type IsDocumentedBy only. 
In this update there are following changes 

- Added  flags to check different  Reference types  (IsDocumentedBy, IsReferencedBy)
- Updated References section to display all the types
- Updated part of the reference links below title of the page, added new line, space, external links symbol 
- As per discussion below title and date modified, only Document references are shown and Under the References section below Description all the references are shown.

Following are some example records
ECBCC1C1301D2ED9E04306570681B10735
ECBCC1C130062ED9E04306570681B10712
333921C30B07D332E0531A5706812AD51458
