### PR TITLE
ODD 588 - must click search entry box twice to enter keywords

### DIFF
--- a/src/client/sdp/adv_search/adv_search.component.html
+++ b/src/client/sdp/adv_search/adv_search.component.html
@@ -32,16 +32,17 @@
         <div class="ui-g-12 ui-md-2">
         </div>
         <div class="ui-g-12 ui-md-4" style="padding-right: 0px;padding-left: 0px;padding-bottom: 0px">
+          <!--
           <div class="well-sm inner-addon left-addon " [hidden]="!textRotate" (click) = "toggleTextRotate()" style="background-color: #FFFFFF;border:1px solid;height: 42px;
       font-weight: 400;font-style: italic;font-size: 16px;border-color: #bdbdbd;border-width: 1px 1px 1px 1px;border-radius: 0px;vertical-align: middle;"  >
             <i class="glyphicon glyphicon-search"></i><span class="element" style="color: gray;display: flex;align-items:center;vertical-align:middle;border-color: #bdbdbd;padding-left:40px;border-width: 1px 1px 1px 1px;">
         Kinetics database |Gallium|"SRD 101" | XPDB | Interatomic Potentials
             </span>
-          </div>
-          <label for="searchinput" class="hideLabel">Search Input</label>
-          <div class="inner-addon left-addon element " style="background-color: #FFFFFF" [hidden]="textRotate" >
+          </div> -->
+          <label for="advsearchinput" class="hideLabel">Search Input</label>
+          <div class="inner-addon left-addon " style="background-color: #FFFFFF">
             <i class="glyphicon glyphicon-search"></i>  <p-autoComplete [inputStyle]="{'width': '100%','padding-left':'40px','height': '42px','font-weight': '400',
-        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue" inputId="searchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
+        'font-style': 'italic','font-size': '20px'}" (onFocus)="clearText()" (onBlur) = "addPlaceholder()" placeholder="" [(ngModel)]="searchValue" inputId="advsearchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
           </p-autoComplete>
           </div>
         </div>

--- a/src/client/sdp/adv_search/adv_search.component.ts
+++ b/src/client/sdp/adv_search/adv_search.component.ts
@@ -51,11 +51,24 @@ export class AdvSearchComponent implements OnInit {
    *
    */
   ngOnInit() {
-    jQuery('.element').atrotating();
+    //jQuery('.element').atrotating();
     this.getTaxonomies();
-      this.getSearchFields();
-      this.rows =  [{}];
-      this.searchOperators();
+    this.getSearchFields();
+    this.rows =  [{}];
+    this.searchOperators();
+    var placeHolder = ['Kinetics database', 'Gallium', '"SRD 101"', 'XPDB', 'Interatomic Potentials'];
+    var i=0;
+    var loopLength=placeHolder.length;
+    setInterval(function(){
+      if(i<loopLength){
+        var newPlaceholder = placeHolder[i];
+        i++;
+        jQuery('#advsearchinput').attr('placeholder',newPlaceholder);
+      } else {
+        jQuery('#advsearchinput').attr('placeholder',placeHolder[0]);
+        i=0;
+      }
+    },2000);
   }
 
 
@@ -134,7 +147,7 @@ export class AdvSearchComponent implements OnInit {
     this.suggestedTaxonomyList = [];
     for(let i = 0; i < this.suggestedTaxonomies.length; i++) {
       let keyw = this.suggestedTaxonomies[i];
-      if(keyw.toLowerCase().indexOf(suggTaxonomy.toLowerCase()) >= 0) {
+      if(keyw.toLowerCase().indexOf(suggTaxonomy.trim().toLowerCase()) >= 0) {
         this.suggestedTaxonomyList.push(keyw);
       }
     }
@@ -252,5 +265,20 @@ export class AdvSearchComponent implements OnInit {
       if (this.rows.length === 1) {
         this.showDeleteButton = false;
       }
+  }
+
+
+  clearText(){
+    var field = (<HTMLInputElement>document.getElementById('searchinput'));
+    if (!Boolean(this.searchValue.trim())) {
+      field.value = ' ';
+    }
+  }
+
+  addPlaceholder() {
+    var field = (<HTMLInputElement>document.getElementById('searchinput'));
+    if (!Boolean(this.searchValue)) {
+      field.value = '';
+    }
   }
 }

--- a/src/client/sdp/home/home.component.html
+++ b/src/client/sdp/home/home.component.html
@@ -32,16 +32,17 @@
         <div class="ui-g-12 ui-md-2">
         </div>
         <div class="ui-g-12 ui-md-4" style="padding-right: 0px;padding-left: 0px;padding-bottom: 0px">
+          <!--
           <div class="well-sm inner-addon left-addon " [hidden]="!textRotate" (click) = "toggleTextRotate()" style="background-color: #FFFFFF;border:1px solid;height: 42px;
       font-weight: 400;font-style: italic;font-size: 16px;border-color: #bdbdbd;border-width: 1px 1px 1px 1px;border-radius: 0px;vertical-align: middle;"  >
             <i class="glyphicon glyphicon-search"></i><span class="element" style="color: gray;display: flex;align-items:center;vertical-align:middle;border-color: #bdbdbd;padding-left:40px;border-width: 1px 1px 1px 1px;">
         Kinetics database |Gallium|"SRD 101" | XPDB | Interatomic Potentials
             </span>
-          </div>
+          </div> -->
           <label for="searchinput" class="hideLabel">Search Input</label>
-          <div class="inner-addon left-addon element " style="background-color: #FFFFFF" [hidden]="textRotate" >
+          <div class="inner-addon left-addon " style="background-color: #FFFFFF">
             <i class="glyphicon glyphicon-search"></i>  <p-autoComplete [inputStyle]="{'width': '100%','padding-left':'40px','height': '42px','font-weight': '400',
-        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue" inputId="searchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
+        'font-style': 'italic','font-size': '20px'}" (onFocus)="clearText()" (onBlur) = "addPlaceholder()" placeholder="" [(ngModel)]="searchValue" inputId="searchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
           </p-autoComplete>
           </div>
 

--- a/src/client/sdp/home/home.component.ts
+++ b/src/client/sdp/home/home.component.ts
@@ -52,15 +52,33 @@ export class HomeComponent implements OnInit {
    *
    */
   ngOnInit() {
-
-    jQuery('.element').atrotating();
       this.getTaxonomies();
       this.getTaxonomySuggestions();
       this.getSearchFields();
       this.rows =  [{}];
       this.searchOperators();
       console.log("taxonomy" + JSON.stringify(this.suggestedTaxonomies));
+      var placeHolder = ['Kinetics database', 'Gallium', '"SRD 101"', 'XPDB', 'Interatomic Potentials'];
+      /*
+      var time = setInterval(function() {
+        var newKeyword = keyword[Math.floor(Math.random()*keyword.length)];
+        var field = document.getElementById('searchinput');
+        jQuery('#searchinput').attr('placeholder', newKeyword);
+      },2000);
+      */
+      var n=0;
+      var loopLength=placeHolder.length;
 
+      setInterval(function(){
+        if(n<loopLength){
+          var newPlaceholder = placeHolder[n];
+          n++;
+          jQuery('#searchinput').attr('placeholder',newPlaceholder);
+        } else {
+          jQuery('#searchinput').attr('placeholder',placeHolder[0]);
+          n=0;
+        }
+      },2000);
   }
 
   /**
@@ -80,6 +98,19 @@ export class HomeComponent implements OnInit {
     }
   }
 
+  clearText(){
+    var field = (<HTMLInputElement>document.getElementById('searchinput'));
+      if (!Boolean(this.searchValue.trim())) {
+        field.value = ' ';
+      }
+  }
+
+  addPlaceholder() {
+    var field = (<HTMLInputElement>document.getElementById('searchinput'));
+    if (!Boolean(this.searchValue)) {
+      field.value = '';
+    }
+  }
   /**
    * Advanced Search builder string
    */
@@ -162,7 +193,7 @@ export class HomeComponent implements OnInit {
     this.suggestedTaxonomyList = [];
     for(let i = 0; i < this.suggestedTaxonomies.length; i++) {
       let keyw = this.suggestedTaxonomies[i];
-      if(keyw.toLowerCase().indexOf(suggTaxonomy.toLowerCase()) >= 0) {
+      if(keyw.toLowerCase().indexOf(suggTaxonomy.trim().toLowerCase()) >= 0) {
         this.suggestedTaxonomyList.push(keyw);
       }
     }

--- a/src/client/sdp/search/search.component.html
+++ b/src/client/sdp/search/search.component.html
@@ -24,7 +24,7 @@
         <div class="ui-g-12 ui-md-4" style="padding-right: 0px;padding-left: 0px;padding-bottom: 0px">
           <div class="inner-addon left-addon element " style="background-color: #FFFFFF" >
             <i class="glyphicon glyphicon-search"></i><label for="searchinput" class="hideLabel">Search Input</label><p-autoComplete [inputStyle]="{'width': '100%','padding-left':'40px','height': '42px','font-weight': '400',
-        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue"  inputId="searchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
+        'font-style': 'italic','font-size': '20px'}"   [(ngModel)]="searchValue"  (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
           </p-autoComplete>
           </div>
         </div>
@@ -184,7 +184,7 @@
                         [style]="{'width':'auto','font-size': '12px','padding-top': '.5em','padding-right': '.5em',
                           'padding-bottom': '.5em','background-color': '#F8F9F9'}"
                         [(selection)]="selectedResourceTypeNode" (onNodeUnselect)="filterResults($event,'')"
-                        (onNodeSelect)="filterResults($event,'')" >
+                        (onNodeSelect)="filterResults($event,'')">
                   <ng-template let-node  pTemplate="default">
                     <span> {{node.label.split("-")[0]}}&nbsp;</span>
                     <span class="badge" style="background-color: #515151" *ngIf = "node.label.split('-')[1] !=''" > {{node.label.split("-")[1]}}</span>
@@ -281,7 +281,7 @@
         </div>
         <div [className]="resultsClass" style="padding: 0px;background-color: #FFFFFF">
           <p-dataList [value]="filteredResults" #results responsive = "true" [paginator]="true" paginatorPosition = "top" [rows]="5"
-                      [style]="{'padding-right': '.5em','height':'auto'}">
+                      [style]="{'padding-right': '.5em','height':'auto'}" >
             <p-header >
               <div class="ui-g ui-grid-responsive" style="padding: 0em;">
                 <div class="ui-g-12" style="padding: 0em">

--- a/src/client/sdp/search/search.component.ts
+++ b/src/client/sdp/search/search.component.ts
@@ -38,6 +38,7 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
   noResults: boolean;
   checked: boolean = false;
   errorMsg: string;
+  first: number = 0;
   status: string;
   errorMessage: string;
   queryAdvSearch: string;


### PR DESCRIPTION
This PR addresses the issue [ODD 588 ("must click search entry box twice to enter keywords")](https://mml.nist.gov:8080/browse/ODD-588). 

When user comes to the SDP home page, one must click in the search entry box twice before one can enter keywords.  Only one click should be necessary.

More specifically, when we first visit the SDP home page, we see the keyword suggestions appearing inside the search box.  When we click in that box, the suggestions stop displaying; however, when we then begin typing, the text does not appear in the search box.  We must click a second time to acquire the entry box's focus; now, when we enter text, the text appears in the box. The first click should be able to capture the entry box focus so that the typed text starts to appear immediately.

please test this PR by clicking on Search input box in Home/Advanced search page, focus should be on Search input box with one click. when the text is entered, placeholder text should go away