### PR TITLE
Fixed About page link on landing page.

### DIFF
--- a/src/client/pdr/shared/headbar/headbar.component.html
+++ b/src/client/pdr/shared/headbar/headbar.component.html
@@ -26,7 +26,7 @@
             <!--<img class="Fleft" srcset="./assets/images/beta-pdr.png"> -->
             <span class="badge" style="background-color:#8f3919">1.0.0-beta</span>
             <span *ngIf="checkinternal()" class="badge" style="background-color:darkcyan">Review Version</span>
-            <div align="right" class="header-links"><a href="/#/about" ><span class="textlinks"><b>About</b></span></a>
+            <div align="right" class="header-links"><a href="/pdr/#/about" ><span class="textlinks"><b>About</b></span></a>
              | <a href="{{ SDPAPI }}" onclick="window.open(this.href, 'search'); return false"><span class="textlinks"><b>Search</b></span></a></div>
         </div>
     </div>


### PR DESCRIPTION
@RayPlante 

The About link /#/about works fine if there is only PDR deployed but since /#/about is same path for SDP about, it goes to sip first so I Updated link to mimic /pdr/#/about.