### PR TITLE
Loading image

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -87,12 +87,14 @@
   </sdp-app>
   <pdr-app>
      <!-- loading layout replaced by app after startupp -->
+    <!-- commenting the loading image as it is affecting SDP too - Som 03/09
      <div class="app-loading">
         <div class="logo"> Loading ..</div>
         <svg class="spinner" viewBox="25 25 50 50">
           <circle class="path" cx="50" cy="50" r="20" fill="none" stroke-width="2" stroke-miterlimit="10"/>
         </svg>
       </div>
+      !-->
   </pdr-app>
 
   <script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>


### PR DESCRIPTION
Comment out PDR loading image code in index.html, as we are seeing the
loading image under footer in SDP pages

Testing - Please access SDP home and Search results pages, under footer there should not be any blank space with loading image. PDR pages will not see loading image when the page is getting loaded