### PR TITLE
Add loading spinner to search results page

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "nanoscroller": "0.8.7",
     "ng2-sticky": "^0.5.0",
     "ng2-utils": "^0.6.1",
-    "primeng": "4.2.2",
+    "primeng": "4.3.0",
     "rxjs": "5.4.3",
 
     "systemjs": "0.20.14",

--- a/src/client/sdp/search/search.component.html
+++ b/src/client/sdp/search/search.component.html
@@ -63,6 +63,13 @@
     </div>
     <div class="EmptyBox80" style="background-color: #FFFFFF;"></div>
   </div>
+  <div>
+  <div class="ui-g-12" *ngIf = "searching">
+    <div class="ui-g-5"></div>
+      <div class="ui-g-7"><p-progressSpinner></p-progressSpinner>
+      </div>
+  </div>
+  </div>
   <div *ngIf="!noResults">
     <div *ngIf="filteredResults.length > 0">
       <div class="ui-g " style="background-color: #F8F9F9;">

--- a/src/client/sdp/search/search.component.ts
+++ b/src/client/sdp/search/search.component.ts
@@ -5,7 +5,7 @@ import 'rxjs/add/operator/map';
 import { Subscription } from 'rxjs/Subscription';
 import { SelectItem, TreeNode, TreeModule } from 'primeng/primeng';
 import { Message } from 'primeng/components/common/api';
-import { MenuItem } from 'primeng/primeng';
+import { MenuItem, ProgressSpinner } from 'primeng/primeng';
 import * as _ from 'lodash';
 import { Config } from '../shared/config/env.config';
 import { environment } from '../environment';
@@ -374,6 +374,7 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
     if (this.filteredResults.length < 5) {
       this.rows = 20;
     }
+    this.searching = false;
   }
 
   /**
@@ -390,6 +391,7 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
     this.errorMsg = (<any>error).message;
     this.status = (<any>error).httpStatus;
     this.msgs.push({severity: 'error', summary: this.errorMsg + ':', detail: this.status + ' - ' + this.exception});
+    this.searching = false;
   }
 
   showMoreResTopics() {

--- a/src/client/sdp/search/search.module.ts
+++ b/src/client/sdp/search/search.module.ts
@@ -9,12 +9,12 @@ import { TaxonomyListService } from '../shared/taxonomy-list/index';
 import { SearchFieldsListService } from '../shared/searchfields-list/index';
 import {
   DropdownModule, AccordionModule, TreeModule, PanelMenuModule, AutoCompleteModule,
-  MessagesModule, MultiSelectModule, DataTableModule, DataListModule,  OverlayPanelModule, CheckboxModule, TooltipModule
+  MessagesModule, MultiSelectModule, ProgressSpinnerModule, DataTableModule, DataListModule,  OverlayPanelModule, CheckboxModule, TooltipModule
 } from 'primeng/primeng';
 
 @NgModule({
     imports: [HttpModule,CommonModule, SharedModule, AccordionModule,AutoCompleteModule,MessagesModule,MultiSelectModule,
-      DropdownModule,DataTableModule, DataListModule,TreeModule, PanelMenuModule, OverlayPanelModule, CheckboxModule, TooltipModule],
+      DropdownModule,DataTableModule, DataListModule,TreeModule, PanelMenuModule, OverlayPanelModule, CheckboxModule, TooltipModule, ProgressSpinnerModule],
     declarations: [SearchPanelComponent,ReadMoreComponent],
     exports: [SearchPanelComponent,ReadMoreComponent],
     providers: [TaxonomyListService, SearchFieldsListService ]


### PR DESCRIPTION
Add loading spinner to Search results page..

Testing - Home page : Enter the search text and click on Search button , Search results page with loading spinner will be displayed, once results are retrieved, loading spinner will be replaced with Search results list.