### PR TITLE
ODD-603: Footer image not loading

### DIFF
--- a/src/client/pdr/shared/footbar/footbar.component.css
+++ b/src/client/pdr/shared/footbar/footbar.component.css
@@ -156,7 +156,7 @@ span.ext {
 }
 
 span.ext {
-    background: url(https://www2.nist.gov/sites/all/modules/contrib/extlink/extlink_s.png) 2px center no-repeat;
+    background: url(https://www.nist.gov/sites/all/modules/contrib/extlink/extlink_s.png) 2px center no-repeat;
     width: 10px;
     height: 10px;
     padding-right: 12px;

--- a/src/client/sdp/shared/footbar/footbar.component.css
+++ b/src/client/sdp/shared/footbar/footbar.component.css
@@ -156,7 +156,7 @@ span.ext {
 }
 
 span.ext {
-    background: url(https://www2.nist.gov/sites/all/modules/contrib/extlink/extlink_s.png) 2px center no-repeat;
+    background: url(https://www.nist.gov/sites/all/modules/contrib/extlink/extlink_s.png) 2px center no-repeat;
     width: 10px;
     height: 10px;
     padding-right: 12px;


### PR DESCRIPTION
This PR addresses the issue [ODD 603 ("SDP/PDR requesting file from inaccessible server")](http://mml.nist.gov:8080/browse/ODD-603). 

external link icon
https://www2.nist.gov/sites/all/modules/contrib/extlink/extlink_s.png is not loading..

Changed host name from www2.nist.gov to www.nist.gov

Testing: No errors in browser debugger.
External link icon is displayed next to the links in the last row of the footer