### PR TITLE
LPS: Control the order that the files appear in

### DIFF
--- a/src/client/pdr/landing/datacomponents.spec.ts
+++ b/src/client/pdr/landing/datacomponents.spec.ts
@@ -1,0 +1,134 @@
+import * as dc from "./datacomponents";
+
+export function main() {
+    let datacomps = [
+        {
+            "@type": ["nrdp:DataFile"],
+            filepath: "a/b"
+        },
+        {
+            "@type": ["nrdp:Subcollection"],
+            filepath: "a/c"
+        },
+        {
+            "@type": [ "nrdp:DataFile" ],
+            filepath: "b/README.md"
+        },
+        {
+            "@type": [ "nrdp:DataFile" ],
+            filepath: "b/a"
+        },
+        {
+            "@type": ["nrdp:Subcollection"],
+            filepath: "a"
+        },
+        {
+            "@type": [ "nrdp:DataFile" ],
+            filepath: "b/c"
+        }
+    ];
+    let nondatacomps = [
+        { "@type": ["goob"] },
+        { "@type": ["gurn"] }
+    ];
+
+    describe("datadcomponents.compare_by_filepath", function() {
+        let a = { "@type": ["goob"], filepath: "a" };
+        let b = { "@type": ["goob"], filepath: "a/b" };
+        
+        it("compares alphabetically by the filepath property", function() {
+            expect(dc.compare_by_filepath(a, b)).toBe(-1);
+            expect(dc.compare_by_filepath(b, a)).toBe(1);
+            expect(dc.compare_by_filepath(a, a)).toBe(0);
+            expect(dc.compare_by_filepath(b, b)).toBe(0);
+        });
+
+        it("can be used to sort an array", function() {
+            let l = [ a, b ];
+            l.sort(dc.compare_by_filepath);
+            expect(l[0].filepath).toBe("a");
+            expect(l[1].filepath).toBe("a/b");
+
+            l = [ b, a ];
+            l.sort(dc.compare_by_filepath);
+            expect(l[0].filepath).toBe("a");
+            expect(l[1].filepath).toBe("a/b");
+        });
+    });
+
+    describe("datacomponents.DataHierarchy", function() {
+        let comps = datacomps.slice();
+        let dh = new dc.DataHierarchy(comps);
+
+        it("can sort a list of data components", function() {
+            expect(dh.data.filepath).toBe("");
+            expect(dh.children.length).toBe(2);
+            expect(dh.children[0].data.filepath).toBe("a");
+            expect(dh.children[1].data.filepath).toBe("b");
+
+            let cdh = dh.children[0]
+            expect(cdh.children[0].data.filepath).toBe("a/c");
+            expect(cdh.children[1].data.filepath).toBe("a/b");
+            expect(cdh.children.length).toBe(2);
+
+            cdh = dh.children[1]
+            expect(cdh.children[0].data.filepath).toBe("b/README.md");
+            expect(cdh.children[1].data.filepath).toBe("b/a");
+            expect(cdh.children[2].data.filepath).toBe("b/c");
+            expect(cdh.children.length).toBe(3);
+        });
+
+        it("can identifiy subcollections", function() {
+            expect(dh.is_subcoll()).toBe(true);
+            expect(dh.children[0].is_subcoll()).toBe(true);
+            expect(dh.children[0].children[0].is_subcoll()).toBe(true);
+            expect(dh.children[0].children[1].is_subcoll()).toBe(false);
+            expect(dh.children[1].children[0].is_subcoll()).toBe(false);
+        });
+    });
+
+    describe("datacomponents.DataComponents", function() {
+        let comps = [ ...datacomps.slice(0, 3), nondatacomps[0],
+                      ...datacomps.slice(3), nondatacomps[1]     ];
+        let rc = new dc.ResComponents(comps);
+
+        it("can wrap a list of components", function() {
+            expect(comps.length).toBe(8);
+            expect(rc.data.length).toBe(8);
+            expect(rc.data[3]["@type"][0]).toBe("goob");
+        });
+
+        it("can filter out data components", function() {
+            let dcs = rc.dataComponentDescs();
+            expect(dcs.length).toBe(6);
+            for(let i=0; i < dcs.length; i++) 
+                expect(dcs[i].hasOwnProperty('filepath')).toBe(true);
+        });
+
+        it("can produce a data hierarchy", function() {
+            let dh = rc.dataHierarchy();
+            expect(dh.data.filepath).toBe("");
+            expect(dh.children.length).toBe(2);
+            expect(dh.children[0].data.filepath).toBe("a");
+            expect(dh.children[1].data.filepath).toBe("b");
+        });
+    });
+
+    /*
+    describe("datacomponents integration", function() {
+        it("can handle a large, deep component list", function() {
+            let nerdm = JSON.parse(fs.readFileSync('spec/data/janaf-hier.json', 'utf8'));
+            let dcs = new dc.ResComponents(nerdm['components']);
+            expect(dcs.data.length > 0).toBe(true);
+
+            let dh = dcs.dataHierarchy();
+            expect(dh.children[0].data.filepath).toBe("aluminum");
+            expect(dh.children[1].data.filepath).toBe("argon");
+            expect(dh.children[1].children[0].data.filepath).toBe("argon/README.txt");
+            expect(dh.children[2].data.filepath).toBe("barium");
+            expect(dh.children[2].children[0].data.filepath).toBe("barium/srd13_Ba-001.json");
+            
+        });
+    });
+    */  
+}

--- a/src/client/pdr/landing/datacomponents.ts
+++ b/src/client/pdr/landing/datacomponents.ts
@@ -51,7 +51,7 @@ export function prefer_readme(a: DataHierarchy, b: DataHierarchy) {
 
     if (fna.toUpperCase().startsWith('README')) {
         if (fnb.toUpperCase().startsWith('README')) 
-            return fna.localeCompare(fna, fnb);
+            return fna.localeCompare(fnb);
         return -1;
     }
     else if (fnb.toUpperCase().startsWith('README')) 

--- a/src/client/pdr/landing/datacomponents.ts
+++ b/src/client/pdr/landing/datacomponents.ts
@@ -1,0 +1,157 @@
+/**
+ * Support for resource components from a NERDm record
+ */
+
+/**
+ * a NERDm resource component description.  This interface is used to recognize
+ * an element in the array value of the NERDm resource property, "components".
+ */
+export interface ComponentDesc {
+    "@type": string[];
+    filepath?: string;
+}
+
+/**
+ * a NERDm data component description.  This interface is used to recognize
+ * an element in the array value of the NERDm resource property, "components",
+ * as a data item (either a DataFile or Subcollection).
+ */
+export interface DataComponentDesc extends ComponentDesc {
+    filepath: string;
+    size?: number;
+}
+
+/**
+ * a compare function for ordering DataCompoentDesc objects alphabeticaly
+ * by their "filepath" properties
+ */
+export function compare_by_filepath(a: DataComponentDesc, b: DataComponentDesc) {
+    return a.filepath.localeCompare(b.filepath);
+}
+
+/**
+ * a compare function for ordering DataHierarchy instances for our display 
+ * preferences
+ */
+export function compare_for_display(a: DataHierarchy, b: DataHierarchy) {
+    let c = prefer_readme(a, b);
+    if (c != 0) return c
+
+    c = prefer_subcollections(a, b);
+    if (c != 0) return c
+
+    return a.data.filepath.localeCompare(b.data.filepath)
+}
+
+export function prefer_readme(a: DataHierarchy, b: DataHierarchy) {
+    let fp = a.data.filepath.split('/');
+    let fna = fp[fp.length-1];
+    fp = b.data.filepath.split('/');
+    let fnb = fp[fp.length-1];
+
+    if (fna.toUpperCase().startsWith('README')) {
+        if (fnb.toUpperCase().startsWith('README')) 
+            return fna.localeCompare(fna, fnb);
+        return -1;
+    }
+    else if (fnb.toUpperCase().startsWith('README')) 
+        return +1;
+    return 0;
+}
+
+function type_is_subcol(e: string,i: number,a: string[]) {
+    return e.endsWith(":Subcollection");
+}
+
+export function prefer_subcollections(a: DataHierarchy, b: DataHierarchy) {
+    let ta = a.data["@type"].filter(type_is_subcol);
+    let tb = b.data["@type"].filter(type_is_subcol);
+
+    if (ta.length > 0) {
+        if (tb.length > 0)
+            return a.data.filepath.localeCompare(b.data.filepath);
+        return -1;
+    }
+    else if (tb.length > 0)
+        return +1;
+    return 0;
+}
+
+/**
+ * a hierarchy of NERDm data components
+ */
+export class DataHierarchy {
+    public children: DataHierarchy[];
+    public data: DataComponentDesc;
+
+    /**
+     * create the hierarchy.  
+     * @param dclist   a list of data component objects 
+     * @param data     the data object that describes this node
+     * @param name     a name for this hierarchy node
+     */  
+    constructor(dclist?: DataComponentDesc[], data?: DataComponentDesc) {
+
+        if (! dclist)
+            dclist = []
+        let c = dclist
+        if (! data) {
+            // this DataHierarchy will represent the top of a hierarchy.
+            // Note: when data is provided, we assume dclist has been sorted.
+            data = { filepath: "", "@type": ["nrdp:Subcollection"] };
+            c = dclist.slice().sort(compare_by_filepath);
+        }
+        this.data = data
+        let filepath = this.data.filepath
+        if (filepath.length > 0) filepath = filepath+'/'
+        this.children = [];
+
+        while (c.length > 0 && c[0].filepath.startsWith(filepath)) {
+            // the next element in c is a descendent of this node
+            let rpath = c[0].filepath.substring(filepath.length)
+            if (rpath.includes("/")) {
+                // there's a missing collection child; create it.
+                let sub = rpath.split("/")[0]
+                this.children.push(
+                    new DataHierarchy(c, { filepath: filepath+sub,
+                                           "@type": ["nrdp:Subcollection"]}))
+            } else {
+                // el is a direct child; any grandchildren will directly
+                // follow it in the list
+                let el = c.shift();
+                this.children.push(new DataHierarchy(c, el))
+            }
+        }
+
+        this.children.sort(compare_for_display)
+    }
+
+    is_subcoll() : boolean {
+        return (this.data["@type"].filter(type_is_subcol).length > 0);
+    }
+}
+
+/**
+ * a list of NERDm resource components.
+ */
+export class ResComponents {
+    constructor(public data: ComponentDesc[]) {
+    }
+
+    /**
+     * select out the data components from the list of NERDm resource components
+     */
+    dataComponentDescs(): DataComponentDesc[] {
+        return this.data.filter(function(el, i, a) {
+            return (el.hasOwnProperty('filepath'))
+        }).map(function(el, i, a) { return <DataComponentDesc>el; })
+    }
+
+    /**
+     * select out the data components and return it as a sorted 
+     * DataHierarchy.
+     */
+    dataHierarchy() {
+        return new DataHierarchy(this.dataComponentDescs())
+    }
+};

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -372,44 +372,6 @@ teststring: string = "Loading !!";
       }
   }
 
-  /*
-  createDataHierarchy(){
-    if (this.recordDisplay['dataHierarchy'] == null )
-      return;
-    for(let fields of this.recordDisplay['dataHierarchy']){
-      if( fields.filepath != null) {
-        if(fields.children != null)
-          this.files.push(this.createChildrenTree(fields.children,
-            fields.filepath));
-        else
-          this.files.push(this.createFileNode(fields.filepath,
-            fields.filepath));
-      }
-    }
-
-
-  }
-
-  createChildrenTree(children:any[], filepath:string){
-    let testObj:TreeNode = {};
-    testObj= this.createTreeObj(filepath.split("/")[filepath.split("/").length-1],filepath);
-    testObj.children=[];
-    for(let child of children){
-      let fname = child.filepath.split("/")[child.filepath.split("/").length-1];
-      if( child.filepath != null) {
-        if(child.children != null)
-          testObj.children.push(this.createChildrenTree(child.children,
-            child.filepath));
-        else
-          testObj.children.push(this.createFileNode(fname,
-            child.filepath));
-      }
-    }
-    return testObj;
-  }
-  */
-
-
   createTreeObj(label :string, data:string){
     let testObj : TreeNode = {};
     testObj = {};

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -356,7 +356,7 @@ teststring: string = "Loading !!";
       this.files = this.createNode4Hierarchy(dh).children;
   }
 
-  createNode4Hierarchy(dnode : DataHierarchy) : object {
+  createNode4Hierarchy(dnode : DataHierarchy) {
       let fp = dnode.data.filepath.split('/');
       let label = fp[fp.length-1];
       

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -353,11 +353,11 @@ teststring: string = "Loading !!";
       let fp = dnode.data.filepath.split('/');
       let label = fp[fp.length-1];
       
-      if (dnode.is_subcol()) {
+      if (dnode.is_subcoll()) {
           let out = createTreeObj(label, dnode.data.filepath);
           out.children = [];
           for(let i=0; i < dnode.children.length; i++) 
-              out.children.push(this.createNod4Hierarchy(dnode.children[i]));
+              out.children.push(this.createNode4Hierarchy(dnode.children[i]));
           return out;
       }
       else {

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -349,12 +349,19 @@ teststring: string = "Loading !!";
     return (Object.keys(obj).length === 0);
   }
 
+  createDataHierarchy() {
+      if (this.recordDisplay['components'] == null)
+          return;
+      let dh = new ResComponents(this.recordDisplay['components']).dataHierarchy();
+      this.files = this.createNode4Hierarchy(dh).children;
+  }
+
   createNode4Hierarchy(dnode : DataHierarchy) : object {
       let fp = dnode.data.filepath.split('/');
       let label = fp[fp.length-1];
       
       if (dnode.is_subcoll()) {
-          let out = createTreeObj(label, dnode.data.filepath);
+          let out = this.createTreeObj(label, dnode.data.filepath);
           out.children = [];
           for(let i=0; i < dnode.children.length; i++) 
               out.children.push(this.createNode4Hierarchy(dnode.children[i]));
@@ -363,13 +370,6 @@ teststring: string = "Loading !!";
       else {
           return this.createFileNode(label, dnode.data.filepath);
       }
-  }
-
-  createDataHierarchy() {
-      if (this.recordDisplay['components'] == null)
-          return;
-      let dh = new ResComponents(this.recordDisplay['components']).dataHierarchy();
-      this.files = createNode4Hierarchy(dh).children;
   }
 
   /*

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -16,6 +16,7 @@ import { environment } from '../environment';
 
 import { SearchResolve } from "./search-service.resolve";
 import { error } from 'selenium-webdriver';
+import { ResComponents, DataHierarchy } from "./datacomponents";
 
 //import * as jsPDF  from 'jspdf';
 declare var Ultima: any;
@@ -348,6 +349,30 @@ teststring: string = "Loading !!";
     return (Object.keys(obj).length === 0);
   }
 
+  createNode4Hierarchy(dnode : DataHierarchy) : object {
+      let fp = dnode.data.filepath.split('/');
+      let label = fp[fp.length-1];
+      
+      if (dnode.is_subcol()) {
+          let out = createTreeObj(label, dnode.data.filepath);
+          out.children = [];
+          for(let i=0; i < dnode.children.length; i++) 
+              out.children.push(this.createNod4Hierarchy(dnode.children[i]));
+          return out;
+      }
+      else {
+          return this.createFileNode(label, dnode.data.filepath);
+      }
+  }
+
+  createDataHierarchy() {
+      if (this.recordDisplay['components'] == null)
+          return;
+      let dh = new ResComponents(this.recordDisplay['components']).dataHierarchy();
+      this.files = createNode4Hierarchy(dh).children;
+  }
+
+  /*
   createDataHierarchy(){
     if (this.recordDisplay['dataHierarchy'] == null )
       return;
@@ -364,7 +389,6 @@ teststring: string = "Loading !!";
 
 
   }
-
 
   createChildrenTree(children:any[], filepath:string){
     let testObj:TreeNode = {};
@@ -383,6 +407,8 @@ teststring: string = "Loading !!";
     }
     return testObj;
   }
+  */
+
 
   createTreeObj(label :string, data:string){
     let testObj : TreeNode = {};


### PR DESCRIPTION
Currently, the Landing Page Service lists data components (files and subcollections) in the order that they are listed in the NERDm record.  This tends to reflect the order of distributions in the POD record received from MIDAS; that is, we have no control over that.  The presentation of the files can be greatly improved if we can control the order that the files are listed in.  

This PR addresses this issue via an update to the Landing Page Service (LPS).  It now applies the following rubric for ordering files and subcollections within the hierarchy (that is, for entries at the same level within the hierarchy):
1. All files with a name starting with "README" appear first, alphabetically.
1. All subcollections appear next, alphabetically.
1. All other files appear last, alphabetically.

(Note: currently, sha files are displayed as downloadable files.  This will not be the case in the near future; however, for now, this rubric always has a sha file following right after the data file it describes.)

The code for ordering this list is provided by a new code file, `datacomponents.ts` within the PDR `landing` module.  The `landing.component.ts` file was updated to use this code.  The new code works directly from the NERDm `components` property, so the `dataHierarchy` is no longer needed.  Unit tests were added as well (via `datacomponents.spec.ts`).

@deoyani: please look over the changes to check that I have not strayed too far from the angular coding conventions.

@GRG2: please test this branch under oar-docker.  Please look at the file listing to see that the above rubric is followed.  These IDs might help:
* JANAF, a hierarchical dataset:  ECBCC1C1301D2ED9E04306570681B10735
* Hounsfield (Levine), a dataset with a README: 5D912CD62BAED286E0531A570681312C1878
If a landing page is missing its right-hand nav bar, a fatal error from the new code likely occurred.
