### PR TITLE
LPS: Display version and version history

### DIFF
--- a/src/client/pdr/landing/landing.component.html
+++ b/src/client/pdr/landing/landing.component.html
@@ -100,9 +100,30 @@
                                 </span>
                             </small>
                         </span><br>
-                        <span class="" *ngIf="recordDisplay.issued">  First Released: <strong>{{recordDisplay.issued}}</strong></span>
-                        <span class="" *ngIf="recordDisplay.modified"> Last modified: <strong>{{recordDisplay.modified}}</strong></span>
+                        <span class="" *ngIf="recordDisplay.version"> Version: <strong>{{recordDisplay.version}}</strong></span>
+                        <span class="" *ngIf="recordDisplay.versionHistory" style="padding-right: 15pt;">...
+                        <i style="cursor: pointer;" class ="faa" aria-hidden="true"
+                           [ngClass]="{'faa-plus-square-o': !clickHistory, 'faa-minus-square-o': clickHistory}"
+                           (click)="closeHistory = !closeHistory; clickHistory = expandHistory();"></i>     
+                        </span>
+                        <span class="" *ngIf="recordDisplay.issued" style="padding-right: 10pt;">  Released: <strong>{{recordDisplay.issued}}</strong></span>
+                        <span class="" *ngIf="recordDisplay.modified" style="padding-right: 10pt;"> Last modified: <strong>{{recordDisplay.modified}}</strong></span>
                     </div>
+                    <div class="card" [collapse]="!closeHistory">
+                        <b>Version History:</b>
+                        <span *ngFor="let release of recordDisplay.versionHistory">
+                           <br> <b [innerHTML]="renderRelVer(release, recordDisplay.version)"></b> &nbsp;&nbsp;
+                           <span *ngIf="release.issued">Released: {{release.issued}}</span>
+                           <span *ngIf="release.location || release.refid"> &nbsp;&nbsp; <i [innerHTML]="renderRelId(release, recordDisplay.version)"></i> </span>
+                           <span *ngIf="release.description"> <br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                             <i>{{release.description}}</i>
+                           </span>
+                        </span>
+                    </div>
+                    <p style="margin-top: 10px;" *ngIf="newer.location">
+                       <b>There is a more recent release of this resource available: &nbsp;&nbsp;
+                       <a href="{{newer.location}}">{{newer.label}}</a></b>
+                    </p>
                 </div>
                 <div  *ngIf="recordDisplay.length !== 0" class="ui-sm-1 visible-xs-block visible-sm-block ">
                     <button type="button" pButton icon="faa faa-list" (click)="menu3.toggle($event)"></button>

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -21,6 +21,69 @@ import { error } from 'selenium-webdriver';
 declare var Ultima: any;
 declare var jQuery: any;
 
+interface reference {
+    refType? : string,
+    "@id"? : string,
+    label? : string,
+    location? : string
+}
+
+function compare_versions(a: string, b: string) : number {
+    let aflds : any[] = a.split(".");
+    let bflds : any[] = b.split(".");
+    let toint = function(el, i, a) {
+        let e = null;
+        try {
+            return parseInt(el);
+        } catch (e) {
+            return el;
+        }
+    }
+    aflds = aflds.map(toint);
+    aflds = bflds.map(toint);
+
+    let i :number = 0;
+    let out : number = 0;
+    for (i=0; i < aflds.length && i < bflds.length; i++) {
+        if (typeof aflds[i] === "number") {
+            if (typeof bflds[i] === "number") {
+                out = <number>aflds[i] - <number>bflds[i];
+                if (out == 0) continue;
+            }
+            else 
+                return +1;
+        }
+        else if (typeof bflds[i] === "number") 
+            return -1;
+        return a.localeCompare(b);
+    }
+    return out;
+}
+
+function compare_dates(a : string, b : string) : number {
+    if (a.includes("Z"))
+        a = a.substring(0, a.indexOf("Z"));
+    if (a.includes("Z"))
+        b = b.substring(0, a.indexOf("Z"));
+
+    let asc = -1, bsc = -1;
+    try {
+        asc = Date.parse(a);
+        bsc = Date.parse(b);
+    } catch (e) { return 0; }
+
+    return asc - bsc;
+}
+
+function compare_histories(a, b) {
+    let out = 0;
+    if (a.issued && b.issued)
+        out = compare_dates(a.issued, b.issued);
+    if (out == 0)
+        out = compare_versions(a.version, b.version);
+    return out;
+}
+
 @Component ({
   moduleId: module.id,
   selector: 'pdr-landing',
@@ -73,7 +136,9 @@ export class LandingPanelComponent implements OnInit, OnDestroy {
   private dataHierarchy: any[]=[];
   isResultAvailable: boolean = true;
   isId : boolean = true;
-teststring: string = "Loading !!";
+  private newer : reference = {};  
+  teststring: string = "Loading !!";
+    
   /**
    * Creates an instance of the SearchPanel
    *
@@ -95,8 +160,8 @@ teststring: string = "Loading !!";
       this.recordDisplay = searchResults["ResultData"][0];
 
     if(this.recordDisplay["@id"] === undefined || this.recordDisplay["@id"] === "" ){
-    this.isId = false;
-    return;
+      this.isId = false;
+      return;
     }
 
     this.type = this.recordDisplay['@type'];
@@ -108,6 +173,7 @@ teststring: string = "Loading !!";
     if(this.recordDisplay['contactPoint'].hasEmail !== undefined && this.recordDisplay['contactPoint'].hasEmail !== "")
       this.isEmail = true;
 
+    this.assessNewer();
     this.updateLeftMenu();
     this.updateRightMenu();
   }
@@ -141,6 +207,63 @@ teststring: string = "Loading !!";
 
   openURL(url:string) {
     window.open(url);
+  }
+
+  /**
+   * analyze the given resource metadata to determine if a newer version is 
+   * available.  Currently, this looks in three places (in order) within the 
+   * NERDm record:
+   * <ol>
+   *   <li> the 'isReplacedBy' property </li>
+   *   <li> as a 'isPreviousVersionOf' reference in the references list.
+   *   <li> in the 'versionHistory' property </li>
+   * </ol>
+   * The checks for last two places may be removed in a future release. 
+   */
+  assessNewer() {
+      if (! this.recordDisplay) return;
+
+      // look for the 'isReplacedBy'; this is expected to be inserted into the
+      // record on the fly by the server based on the values of 'replaces' in
+      // all other resources.
+      if (this.recordDisplay['isReplacedBy']) {
+          this.newer = this.recordDisplay['isReplacedBy'];
+          if (! this.newer['refid']) this.newer['refid'] = this.newer['@id'];
+          return;
+      }
+
+      // look for a reference with refType="isPreviousVersionOf"; the
+      // referenced resource is a newer version. 
+      if (this.recordDisplay['references']) {
+          for (let ref of this.recordDisplay['references']) {
+              if (ref.refType == "IsPreviousVersionOf" && (ref.label || ref.refid)) {
+                  this.newer = ref;
+                  if (! this.newer['refid']) this.newer['refid'] = this.newer['@id'];
+                  if (! this.newer.label) this.newer.label = ref.newer.refid;
+                  return;
+              }
+          }
+      }
+
+      // look at the version history to see if there is a newer version listed
+      if (this.recordDisplay['version'] && this.recordDisplay['versionHistory']) {
+          let history = this.recordDisplay['versionHistory'];
+          history.sort(compare_histories);
+          if (compare_histories(history[history.length-1],
+                                { version: this.recordDisplay['version'], 
+                                  issued: this.recordDisplay['modified']  }) > 0)
+          {
+              this.newer = history[history.length-1];
+              if (! this.newer['refid']) this.newer['refid'] = this.newer['@id'];
+              this.newer['label'] = this.newer['version'];
+              if (! this.newer['location'] && this.newer['refid']) {
+                  if (this.newer['refid'].startsWith("doi:"))
+                      this.newer.location = 'https://doi.org/'+this.newer['refid'].substring(4);
+                  else if (this.newer['refid'].startsWith("ark:/88434/"))
+                      this.newer.location = 'https://data.nist.gov/od/id/'+this.newer['refid'].substring(4);
+              }
+          }
+      }
   }
 
   /**
@@ -403,6 +526,51 @@ teststring: string = "Loading !!";
     endFileNode.expandedIcon = "faa faa-folder-open";
     endFileNode.collapsedIcon =  "faa fa-folder";
     return endFileNode;
+  }
+
+  visibleHistory = false;
+  expandHistory() {
+    this.visibleHistory = ! this.visibleHistory;
+    return this.visibleHistory;
+  }
+
+  /**
+   * create an HTML rendering of a version string for a NERDm VersionRelease.  
+   * If there is information available for linking to version's home page, a 
+   * link is returned.  Otherwise, just the version is returned (prepended 
+   * with a "v").
+   */
+  renderRelVer(relinfo, thisversion) {
+      if (thisversion == relinfo.version)
+          return "v"+relinfo.version;
+      return this.renderRelAsLink(relinfo, "v"+relinfo.version);
+  }
+
+  renderRelAsLink(relinfo, linktext) {
+      let out : string = linktext;
+      if (relinfo.location) 
+          out = '<a href="'+relinfo.location+'">'+linktext+'</a>';
+      else if (relinfo.refid) {
+          if (relinfo.refid.startsWith("doi:"))
+              out = '<a href="https://doi.org/'+relinfo.refid.substring(4)+'">'+linktext+'</a>';
+          else if (relinfo.refid.startsWith("ark:/88434/"))
+              out = '<a href="https://data.nist.gov/od/id/'+relinfo.refid+'">'+linktext+'</a>';
+      }
+      return out;
+  }
+
+  /**
+   * return a rendering of a release's ID.  If possible, the ID will be 
+   * rendered as a link.  If there is no ID, a link with the text "View..." 
+   * is returned. 
+   */
+  renderRelId(relinfo, thisversion) {
+      if (thisversion == relinfo.version)
+          return "this version";
+
+      let id : string = "View...";
+      if (relinfo.refid) id = relinfo.refid;
+      return this.renderRelAsLink(relinfo, id);
   }
 
   clicked = false;


### PR DESCRIPTION
This PR is motivated by the [Levine project](https://doi.org/10.18434/M3M956) in which we are publishing a new version of an existing publication.  We want to be able display the current version, give access to other versions, and--most importantly--display a special notice when viewing a deprecated version.  This PR updates the Landing Page Service (LPS) to render version information from the inut NERDm record onto the landing page.  There are companion PRs in [`oar-metadata` (PR#28)](https://github.com/usnistgov/oar-metadata/pull/28)  and [`oar-pdr` (PR#38)](https://github.com/usnistgov/oar-pdr/pull/38).  The former updates the NERDm schema to add the needed metadata about versions, and the latter updates the publishing component to use the new NERDm schema when producing records.  

In this PR, the version string is printed to the line that currently includes the release and modification dates. Included in that display is a clickable icon for expanding a version history (hidden initially).  If there a newer version of the resource available (or otherwise there is another resource that deprecates the currently viewed one), A bold note is displayed to this effect below the version information, including a link to new version.

This PR is targeted to the [1.0.X](https://github.com/usnistgov/oar-sdp/tree/rel/1.0.X) series to enable deployment on the currently released system.  It will need to be ported to the server-side (being added to the [oar-pdr](https://github.com/usnistgov/oar-pdr) repository) later.