### PR TITLE
Revert "Search results filter"

### DIFF
--- a/src/client/sdp/search/search.component.ts
+++ b/src/client/sdp/search/search.component.ts
@@ -441,13 +441,6 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
     if (this.filteredResults.length < 5) {
       this.rows = 20;
     }
-    if (!_.isEmpty(this.searchTaxonomyKey))
-    {
-        this.searchResTopics = this.searchTaxonomyKey;
-    }
-    if ((!_.isEmpty(this.searchResTopics))) {
-      this.setThemesSelection(this.themesWithCount, decodeURIComponent(this.searchResTopics.toString().replace(/\+/g,  " ")));
-    }
     this.searching = false;
   }
 
@@ -488,7 +481,6 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
         searchResults => that.onSuccess(searchResults),
         error => that.onError(error)
       );
-
   }
 
   getTaxonomySuggestions() {
@@ -1364,7 +1356,6 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
    * Get the params OnInit
    */
   ngOnInit() {
-
     this.getSearchFields();
     this.getTaxonomySuggestions();
         this._routeParamsSubscription = this.router.queryParams.subscribe(params => {
@@ -1377,15 +1368,7 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
           this.searchRecord = params['compType'];
           this.searchAuthors = params['authors'];
           this.searchKeywords = params['keywords'];
-          if (!_.isEmpty(this.searchTaxonomyKey))
-          {
-            if (!_.isEmpty(this.searchResTopics)) {
-              this.searchResTopics += this.searchTaxonomyKey;
-            } else {
-              this.searchResTopics = this.searchTaxonomyKey;
-            }
-          }
-          console.log("theme" + this.searchResTopics);
+
           //this.resourceTypeTree.push(params['resType']);
           this.getTaxonomies();
 


### PR DESCRIPTION
Reverts usnistgov/oar-sdp#187

A few problems discovered after an initial merge.

Once the domain drop down selection is searched,   the filter does have correct selection.  However,   there are a few glitches.   If you select Chemistry in domain drop down,  perform search,   then select All Research and perform search,  the Chemistry filter checkbox remains.    This is not consistent behavior across all the domain entries,  which is peculiar.

Also,  occasionally trying to uncheck box in the filters sometimes completely clears the page,  no search box.   Empty page with only the header remaining.