### PR TITLE
Eliminate access to "download all" function

### DIFF
--- a/src/client/pdr/landing/description.component.ts
+++ b/src/client/pdr/landing/description.component.ts
@@ -80,9 +80,7 @@ import { TreeModule,TreeNode, Tree, MenuItem } from 'primeng/primeng';
              <br>
             </div> 
             <div *ngIf="files.length != 0">           
-                <h3 id="files" name="files"><b>Files</b>
-                   <a href="{{distdownload}}" class="faa faa-file-archive-o" title="Download All Files" ></a>
-                </h3>
+                <h3 id="files" name="files"><b>Files</b></h3>
                 <div class="ui-g">
                     <div class="ui-g-6 ui-md-6 ui-lg-6 ui-sm-12">
                         <p-tree [value]="files" selectionMode="single" [(selection)]="selectedFile" (onNodeSelect)="nodeSelect($event)">

--- a/src/client/pdr/landing/landing.component.ts
+++ b/src/client/pdr/landing/landing.component.ts
@@ -331,12 +331,14 @@ export class LandingPanelComponent implements OnInit, OnDestroy {
       
       var itemsMenu: any[] = [];
       var homepage = this.createMenuItem("Visit Home Page",  "faa faa-external-link", '',this.recordDisplay['landingPage']);
-      var download = this.createMenuItem("Download all data","faa faa-file-archive-o", '', this.distdownload);
+      // var download = this.createMenuItem("Download all data","faa faa-file-archive-o", '', this.distdownload);
       var metadata = this.createMenuItem("Export JSON", "faa faa-file-o",'',this.serviceApi);
     
         itemsMenu.push(homepage);
-        if (this.files.length != 0)
-            itemsMenu.push(download);
+        // Disabling download-all; problematic implementation!
+        //
+        // if (this.files.length != 0)
+        //    itemsMenu.push(download);
         itemsMenu.push(metadata);   
          
       this.rightmenu = [{


### PR DESCRIPTION
The implementation of the distribution services "download all" function (in which all data files are zipped up and downloaded as a single file) is problematic and appears to be the reason for the service running out of memory. The easiest way to avoid this problem is removing access to the function on the landing pages. This PR does that.

Eventually, the distribution service will be re-written more robustly.