### PR TITLE
Fix/odd 635 sdp correct domain selected search results management

### DIFF
--- a/src/client/sdp/adv_search/adv_search.component.css
+++ b/src/client/sdp/adv_search/adv_search.component.css
@@ -171,3 +171,39 @@ input[type="file"] {
 .how-to-build {
   padding-top:15px;
 }
+
+@media screen and (min-width: 901px) {
+  button.searchButton {
+    font-size: 20px;
+  }
+}
+
+@media screen and (max-width: 900px) {
+  button.searchButton {
+    font-size: 15px;
+  }
+}
+
+@media screen and (min-width: 1301px) {
+  p-dropdown {
+    font-size: 16px;
+  }
+}
+
+@media screen and (max-width: 1300px) {
+  p-dropdown {
+    font-size: 13px;
+  }
+}
+
+@media screen and (min-width: 1301px) {
+  p-autoComplete {
+    font-size: 16px;
+  }
+}
+
+@media screen and (max-width: 1300px) {
+  p-autoComplete {
+    font-size: 13px;
+  }
+}

--- a/src/client/sdp/adv_search/adv_search.component.html
+++ b/src/client/sdp/adv_search/adv_search.component.html
@@ -35,7 +35,7 @@
           <label for="advsearchinput" class="hideLabel">Search Input</label>
           <div class="inner-addon left-addon " style="background-color: #FFFFFF">
             <i class="glyphicon glyphicon-search"></i>  <p-autoComplete [inputStyle]="{'width': '100%','padding-left':'40px','height': '42px','font-weight': '400',
-        'font-style': 'italic','font-size': '20px'}" (onFocus)="clearText()" (onBlur) = "addPlaceholder()" placeholder="" [(ngModel)]="searchValue" inputId="advsearchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
+        'font-style': 'italic'}" (onFocus)="clearText()" (onBlur) = "addPlaceholder()" placeholder="" [(ngModel)]="searchValue" inputId="advsearchinput" (keyup.enter) = "search(searchValue,searchTaxonomyKey,queryAdvSearch)" [suggestions]="suggestedTaxonomyList" (completeMethod)="filterTaxonomies($event)" [minLength]="1" [maxlength] = "2048" [size] = "50" >
           </p-autoComplete>
           </div>
         </div>

--- a/src/client/sdp/adv_search/adv_search.component.html
+++ b/src/client/sdp/adv_search/adv_search.component.html
@@ -29,7 +29,7 @@
   <div class="ui-g ">
     <div class="ui-g-12">
       <div class="ui-g form-group">
-        <div class="ui-g-12 ui-md-2">
+        <div class="ui-g-12 ui-lg-2 ui-md-1">
         </div>
         <div class="ui-g-12 ui-md-4" style="padding-right: 0px;padding-left: 0px;padding-bottom: 0px">
           <label for="advsearchinput" class="hideLabel">Search Input</label>
@@ -39,7 +39,7 @@
           </p-autoComplete>
           </div>
         </div>
-        <div class="ui-g-12 ui-md-2" style="padding-left: 0px;padding-right: 0px;padding-bottom: 0px">
+        <div class="ui-g-12 ui-lg-2 ui-md-4" style="padding-left: 0px;padding-right: 0px;padding-bottom: 0px">
           <p-dropdown [options]="taxonomies"  inputId="searchtaxonomy" [style]="{'width':'100%',
         'background-color': '#FFFFFF','height': '42px'
         ,'font-weight': '900','font-style': 'italic','display': 'flex','align-items':'center'}" [(ngModel)]="searchTaxonomyKey" >


### PR DESCRIPTION
Fix to the issue: when Advanced Search page resized, some long search topic name will overlap with the down arrow.