### PR TITLE
Update build and test scripts post-pdr migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 # tests for now
 # 
 script:
-  - scripts/testall.travis pdr
+  - scripts/testall.travis --unitonly
 # script:
 #   - scripts/testall
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,20 +16,21 @@ install:
   - npm i -g npm@^5.3.0 && npm --version
   - npm install
 
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+# before_script:
+#   - export DISPLAY=:99.0
+#   - sh -e /etc/init.d/xvfb start
 
 # e2e tests are not currently working under Travis; running only unit
 # tests for now
 # 
-script:
-  - scripts/testall.travis --unitonly
 # script:
-#   - scripts/testall
+#   - scripts/testall.travis --unitonly
+script:
+   - scripts/testall
+   - scripts/makedist
 
-after_script:
-  - pkill gulp
+# after_script:
+#   - pkill gulp
 
 cache:
   directories: node_modules

--- a/scripts/makedist
+++ b/scripts/makedist
@@ -10,9 +10,25 @@ PACKAGE_DIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
 DIST_DIR=$PACKAGE_DIR/dist
 builddir=$PACKAGE_DIR/dist
 
+# this is needed because realpath is not on macs
+function realpath {
+    if [ -d "$1" ]; then
+        (cd $1 && pwd)
+    elif [ -f "$1" ]; then
+        file=`basename $1`
+        parent=`dirname $1`
+        realdir=`(cd $parent && pwd)`
+        echo "$realdir/$file"
+    elif [[ $1 = /* ]]; then
+        echo $1
+    else
+        echo "$PWD/${1#./}"
+    fi
+}
+
 # Update this list with the names of the individual component names
 # 
-DISTNAMES="sdp pdr-lps"
+DISTNAMES="sdp"
 
 # handle command line options
 build_dist=

--- a/scripts/testall.travis
+++ b/scripts/testall.travis
@@ -8,7 +8,7 @@ execdir=`dirname $0`
 [ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
 PACKAGE_DIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
 
-components="pdr sdp"
+components="sdp"
 args="$@"
 [ -n "$args" ] || args=$components
 unrec=
@@ -74,6 +74,8 @@ fi
 trap "{ pkill gulp || true; exit $failed; }" EXIT
 
 if { echo " $args " | grep -qs " pdr "; }; then
+    # DEPRECATED!!
+    
     # run pdr e2e tests
     # set -x
     echo '#' Running pdr e2e tests


### PR DESCRIPTION
The Landing Page Service (LPS) was originally part of the `oar-sdp` repository.  After transitioning to server side rendering, the LPS code was migrated to [`oar-pdr`](https://github.com/usnistgov/oar-pdr). 
The code that currently remains in `oar-sdp` is the earlier 1.0.X version; eventually, this should be removed from the repository.  Meanwhile, the build and test scripts, `scripts/makedist` and `scripts/testall`, were still set-up to build and test both the sdp and pdr codes.  This PR makes minor changes to these (and `scripts/testall.travis`) to turn off the support for the pdr-related code.  

To build the sdp component only, it is now sufficient to just type `scripts/makedist`, and to test, `scripts/testall`.  The `scripts/testall.travis` is used to run tests on travis, which builds and only executes the unit tests; e2e tests are not currently working.  