### PR TITLE
Changed version to 1.1.0 and footer logo link

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "jquery": "^3.2.1",
     "jquery.auto-text-rotating": "^1.3.2",
     "jspdf": "^1.3.3",
-    "lodash": "4.17.5",
+    "lodash": "4.17.11",
     "moment": "^2.17.1",
     "nanoscroller": "0.8.7",
     "ng2-sticky": "^0.5.0",

--- a/src/client/sdp/app.searchtopbar.component.ts
+++ b/src/client/sdp/app.searchtopbar.component.ts
@@ -17,7 +17,7 @@ import * as _ from 'lodash';
             <span class="Fleft" style="font-weight:bold;line-height: 16.5px;display: table-cell;vertical-align: text-top;color: #FFFFFF;font-size:14px;padding-left: 2%">SCIENCE <br> DATA PORTAL </span>
           </a>
       </span>
-      <span class="badge" style="background-color:#982800;vertical-align: text-top;margin-top: 10px;">1.1.0</span>
+      <span class="badge" style="color:black;background-color:#f0f0f0;vertical-align: text-top;margin-top: 10px;">1.1.7</span>
         <div class="topbar-right">
               <a id="menu-button" href="#" (click)="app.onMenuButtonClick($event)">
                     <i></i>

--- a/src/client/sdp/app.searchtopbar.component.ts
+++ b/src/client/sdp/app.searchtopbar.component.ts
@@ -17,7 +17,7 @@ import * as _ from 'lodash';
             <span class="Fleft" style="font-weight:bold;line-height: 16.5px;display: table-cell;vertical-align: text-top;color: #FFFFFF;font-size:14px;padding-left: 2%">SCIENCE <br> DATA PORTAL </span>
           </a>
       </span>
-      <span class="badge" style="background-color:#982800;vertical-align: text-top;margin-top: 10px;">1.1.0-beta</span>
+      <span class="badge" style="background-color:#982800;vertical-align: text-top;margin-top: 10px;">1.1.0</span>
         <div class="topbar-right">
               <a id="menu-button" href="#" (click)="app.onMenuButtonClick($event)">
                     <i></i>

--- a/src/client/sdp/shared/footbar/footbar.component.html
+++ b/src/client/sdp/shared/footbar/footbar.component.html
@@ -29,7 +29,7 @@
         </div>
 
         <div class="footer__logo">
-            <a href="" title="National Institute of Standards and Technology" class="footer__logo-link" rel="home">
+            <a href="https://www.nist.gov" title="National Institute of Standards and Technology" class="footer__logo-link" rel="home">
                 <img srcset="./assets/images/logo_rev.png" alt="National Institute of Standards and Technology" title="National Institute of Standards and Technology">
             </a>
         </div>


### PR DESCRIPTION
Please review the following two changes:
1. Changed the version tag from "1.1.0 beta" to "1.1.0".
2. Linked the NIST logo in the footer to nist.gov instead of home.