### PR TITLE
ODD-737: Updated social media icons and top logo tooltip

### DIFF
--- a/src/client/sdp/app.searchtopbar.component.ts
+++ b/src/client/sdp/app.searchtopbar.component.ts
@@ -11,10 +11,10 @@ import * as _ from 'lodash';
     template: `
     <div class="topbar" style="background-color: #000000">
       <span class="topbar-left" style="background-color: #000000;">
-          <a href="/" style="text-decoration: none" title="National Institute of Standards and Technology" class="header__logo-link" rel="home">
+          <a href="/" style="text-decoration: none" title="NIST Science Data Portal" class="header__logo-link" rel="home">
           <img class="Fleft top_bar" srcset="./assets/images/nist_logo_reverse.png" 
-          alt="National Institute of Standards and Technology" title="National Institute of Standards and Technology" >
-            <span class="Fleft" style="font-weight:bold;line-height: 16.5px;display: table-cell;vertical-align: text-top;color: #FFFFFF;font-size:14px;padding-left: 2%">SCIENCE <br> DATA PORTAL </span>
+          alt="NIST Science Data Portal" title="NIST Science Data Portal" >
+            <span class="Fleft" style="font-weight:bold;line-height: 16.5px;display: table-cell;vertical-align: text-top;color: #FFFFFF;font-size:14px;padding-left: 2%">SCIENCE<br> DATA PORTAL </span>
           </a>
       </span>
       <span class="badge" style="color:black;background-color:#f0f0f0;vertical-align: text-top;margin-top: 10px;">1.1.7</span>

--- a/src/client/sdp/shared/footbar/footbar.component.html
+++ b/src/client/sdp/shared/footbar/footbar.component.html
@@ -17,14 +17,15 @@
 
         <div class="social-links">
             <div class="item-list">
-                <ul>
-                    <li ><a href="https://twitter.com/USNISTGOV" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-twitter"><span class="element-invisible">twitter</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
-                    <li class="field-item service-facebook list-horiz"><a href="https://www.facebook.com/USNISTGOV" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-facebook"><span class="element-invisible">facebook</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
-                    <li class="field-item service-googleplus list-horiz"><a href="https://plus.google.com/+USNISTGOV" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-google-plus"><span class="element-invisible">google plus</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
-                    <li class="field-item service-youtube list-horiz"><a href="https://www.youtube.com/user/USNISTGOV" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-youtube"><span class="element-invisible">youtube</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
-                    <li class="field-item service-rss list-horiz"><a href="https://www2.nist.gov/news-events/nist-rss-feeds" target="_blank" class="social-btn social-btn--large extlink"><i class="faa faa-rss"><span class="element-invisible">rss</span></i></a></li>
-                    <li class="field-item service-govdelivery list-horiz last"><a href="https://service.govdelivery.com/accounts/USNIST/subscriber/new" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-envelope"><span class="element-invisible">govdelivery</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
-                </ul>
+              <ul>
+                <li ><a href="https://twitter.com/USNISTGOV" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-twitter"><span class="element-invisible">twitter</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
+                <li class="field-item service-facebook list-horiz"><a href="https://www.facebook.com/USNISTGOV" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-facebook"><span class="element-invisible">facebook</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
+                <li><a href="https://www.linkedin.com/company/nist" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-linkedin"><span class="element-invisible">linkedin</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
+                <li ><a href="https://www.instagram.com/usnistgov/" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-instagram"><span class="element-invisible">Instagram</span></i><span class="ext" aria-label="(link is external)"></span></a></li>
+                <li class="field-item service-youtube list-horiz"><a href="https://www.youtube.com/user/USNISTGOV" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-youtube"><span class="element-invisible">youtube</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
+                <li class="field-item service-rss list-horiz"><a href="https://www.nist.gov/news-events/nist-rss-feeds" target="_blank" class="social-btn social-btn--large extlink"><i class="faa faa-rss"><span class="element-invisible">rss</span></i></a></li>
+                <li class="field-item service-govdelivery list-horiz last"><a href="https://service.govdelivery.com/accounts/USNIST/subscriber/new" target="_blank" class="social-btn social-btn--large extlink ext"><i class="faa faa-envelope"><span class="element-invisible">govdelivery</span></i><span class="ext"><span class="element-invisible"> (link is external)</span></span></a></li>
+              </ul>
             </div>
         </div>
 


### PR DESCRIPTION
Jira link: http://mml.nist.gov:8080/browse/ODD-737

I re-used this old ticket since the issue is similar.

1. Social media buttons: removed G+ and added Instagram and Linked in. The background color issue will be fixed in the none-Angular-seed version.
2. When mouse over top left NIST logo now it display "NIST Science Data Portal".