### PR TITLE
fix/ODD773 Add Google Analytics tracking code

### DIFF
--- a/angular/src/app/about/about.component.html
+++ b/angular/src/app/about/about.component.html
@@ -11,8 +11,6 @@
     top.location = self.location;
   }
 </script>
-<script async type="text/javascript" id="_fed_an_ua_tag"
-  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
 
 <div class="ui-g" style="width: 100%;background-color: #153971;color: #FFFFFF">
   <div class="ui-g-12" style="padding-left:2.5em;padding-right: 2.5em;padding-top: 2.5em">

--- a/angular/src/app/about/about.component.html
+++ b/angular/src/app/about/about.component.html
@@ -11,11 +11,13 @@
     top.location = self.location;
   }
 </script>
-
+<script async type="text/javascript" id="_fed_an_ua_tag"
+  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
 
 <div class="ui-g" style="width: 100%;background-color: #153971;color: #FFFFFF">
   <div class="ui-g-12" style="padding-left:2.5em;padding-right: 2.5em;padding-top: 2.5em">
-    <label id='title' style="font-size: xx-large;float: left;display: block;"><i class="faa faa-info-circle faa-lg"></i>About NIST Data</label>
+    <label id='title' style="font-size: xx-large;float: left;display: block;"><i
+        class="faa faa-info-circle faa-lg"></i>About NIST Data</label>
     <ol class="breadcrumb" style="float: right;">
       <li class="breadcrumb-item"><a href="#" style="color: #fff;">Home</a></li>
       <li class="active breadcrumb-item">About</li>
@@ -27,33 +29,42 @@
 <div class="card">
   <div class="ui-g">
     <div class="ui-g-12">
-      <div class="ui-g-12 ui-md-6 ui-lg-6 content" style="font-family: Source Sans Pro,sans-serif;font-size:20px;line-height: 1.2em;">
+      <div class="ui-g-12 ui-md-6 ui-lg-6 content"
+        style="font-family: Source Sans Pro,sans-serif;font-size:20px;line-height: 1.2em;">
         <div class="adv-step">
           Data products developed and distributed by the National Institute of Standards and Technology span multiple
           disciplines of research and are widely used in research and development programs by industry and academia.
         </div>
         <div class="adv-step">
-          NIST's publicly available data sets showcase its committment to providing accurate, well-curated measurements of
-          physical properties, exemplified by the <a href="https://www.nist.gov/srd" target="_blank"> Standard Reference Data program</a>, as well as its committment
+          NIST's publicly available data sets showcase its committment to providing accurate, well-curated measurements
+          of
+          physical properties, exemplified by the <a href="https://www.nist.gov/srd" target="_blank"> Standard Reference
+            Data program</a>, as well as its committment
           to advancing basic research.
         </div>
         <div class="adv-step">
-          In accordance with U.S. Government Open Data Policy and the <a href="https://www.nist.gov/open" target="_blank">NIST Plan</a> for providing public access to
-          the results of federally funded research data, NIST maintains a publicly accessible listing of available data, the
-          NIST Public Dataset List <a href="https://www.nist.gov/sites/default/files/data.json" target="_blank">(json)</a>. Additionally, these data are assigned a Digital Object
+          In accordance with U.S. Government Open Data Policy and the <a href="https://www.nist.gov/open"
+            target="_blank">NIST Plan</a> for providing public access to
+          the results of federally funded research data, NIST maintains a publicly accessible listing of available data,
+          the
+          NIST Public Dataset List <a href="https://www.nist.gov/sites/default/files/data.json"
+            target="_blank">(json)</a>. Additionally, these data are assigned a Digital Object
           Identifier (DOI) to increase the discovery and access to research output; these DOIs are registered with
-          <a href="https://www.datacite.org" target="_blank">DataCite</a> and provide globally unique persistent identifiers. The NIST Science Data Portal provides a
+          <a href="https://www.datacite.org" target="_blank">DataCite</a> and provide globally unique persistent
+          identifiers. The NIST Science Data Portal provides a
           user-friendly discovery and exploration tool for publically available datasets at NIST.
         </div>
         <hr>
         <div class="adv-step">
-          This portal is designed and developed with data.gov <a href="https://project-open-data.cio.gov/" target="_blank">Project Open Data </a> standards and principles. The portal software is hosted in the usnistgov github repository.
+          This portal is designed and developed with data.gov <a href="https://project-open-data.cio.gov/"
+            target="_blank">Project Open Data </a> standards and principles. The portal software is hosted in the
+          usnistgov github repository.
         </div>
       </div>
-        <div class="ui-g-12 ui-md-6 ui-lg-1">
+      <div class="ui-g-12 ui-md-6 ui-lg-1">
       </div>
       <div class="ui-g-12 ui-md-6 ui-lg-4">
-          <img class="Fleft" src="./assets/images/AboutNIST-Large.png" alt="AboutNIST"  >
+        <img class="Fleft" src="./assets/images/AboutNIST-Large.png" alt="AboutNIST">
 
       </div>
     </div>

--- a/angular/src/app/about/about.component.ts
+++ b/angular/src/app/about/about.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-declare var gas:Function;
-
 @Component({
   selector: 'sdp-about',
   templateUrl: './about.component.html',
@@ -12,7 +10,6 @@ export class AboutComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
-    gas('create', 'pageview');
   }
 
 }

--- a/angular/src/app/about/about.component.ts
+++ b/angular/src/app/about/about.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
+declare var gas:Function;
+
 @Component({
   selector: 'sdp-about',
   templateUrl: './about.component.html',
@@ -10,6 +12,7 @@ export class AboutComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
+    gas('create', 'pageview');
   }
 
 }

--- a/angular/src/app/adv-search/adv-search.component.html
+++ b/angular/src/app/adv-search/adv-search.component.html
@@ -11,8 +11,6 @@
     top.location = self.location;
   }
 </script>
-<script async type="text/javascript" id="_fed_an_ua_tag"
-  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
 
 <div class="ui-g" style="background-color: #153971;color: #FFFFFF">
   <div class="ui-g-2">

--- a/angular/src/app/adv-search/adv-search.component.html
+++ b/angular/src/app/adv-search/adv-search.component.html
@@ -11,13 +11,16 @@
     top.location = self.location;
   }
 </script>
+<script async type="text/javascript" id="_fed_an_ua_tag"
+  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
 
 <div class="ui-g" style="background-color: #153971;color: #FFFFFF">
   <div class="ui-g-2">
   </div>
   <div class="ui-g-10">
     <div class="EmptyBox20"></div>
-    <label id='title' style="font-size: xx-large;float: left;display: block;"><i class="faa faa-cogs faa-lg"></i>Advanced Search Builder</label>
+    <label id='title' style="font-size: xx-large;float: left;display: block;"><i
+        class="faa faa-cogs faa-lg"></i>Advanced Search Builder</label>
     <ol class="breadcrumb" style="float: right;">
       <li class="breadcrumb-item"><a href="#" style="color: #fff;">Home</a></li>
       <li class="active breadcrumb-item">Advanced Search Builder</li>
@@ -34,7 +37,7 @@
         <div class="ui-g-12 ui-md-4" style="padding-right: 0px;padding-left: 0px;padding-bottom: 0px">
           <label for="advsearchinput" class="hideLabel">Search Input</label>
           <div class="inner-addon left-addon " style="background-color: #FFFFFF">
-              <i class="glyphicon faa faa-search"></i>
+            <i class="glyphicon faa faa-search"></i>
             <p-autoComplete [inputStyle]="{'width': '100%','padding-left':'40px','height': '42px','font-weight': '400',
         'font-style': 'italic'}" (onFocus)="clearText()" (onBlur)="addPlaceholder()" [placeholder]="placeholder"
               [(ngModel)]="searchValue" inputId="advsearchinput"
@@ -63,12 +66,15 @@
       </div>
       <div class="ui-g-12 ui-md-6">
         <b> Examples: </b>
-        <a class="examples" (click)="$event.preventDefault();searchExample('&quot;Kinetics database&quot;');" href="#!">"Kinetics database" </a>
+        <a class="examples" (click)="$event.preventDefault();searchExample('&quot;Kinetics database&quot;');"
+          href="#!">"Kinetics database" </a>
         &nbsp;
         <a class="examples" (click)="$event.preventDefault();searchExample('Gallium');" href="#!">Gallium </a>&nbsp;
-        <a class="examples" (click)="$event.preventDefault();searchExample('&quot;SRD 101&quot;');" href="#!">"SRD 101" </a>&nbsp;
+        <a class="examples" (click)="$event.preventDefault();searchExample('&quot;SRD 101&quot;');" href="#!">"SRD 101"
+        </a>&nbsp;
         <a class="examples" (click)="$event.preventDefault();searchExample('XPDB');" href="#!">XPDB </a>&nbsp;
-        <a class="examples" (click)="$event.preventDefault();searchExample('Interatomic Potentials');" href="#!">Interatomic Potentials
+        <a class="examples" (click)="$event.preventDefault();searchExample('Interatomic Potentials');"
+          href="#!">Interatomic Potentials
         </a>&nbsp;
       </div>
     </div>

--- a/angular/src/app/help/help.component.html
+++ b/angular/src/app/help/help.component.html
@@ -11,6 +11,8 @@
     top.location = self.location;
   }
 </script>
+<script async type="text/javascript" id="_fed_an_ua_tag"
+  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
 
 <div class="sdp-help-page">
   <div class="ui-g" style="width: 100%;background-color: #153971;color: #FFFFFF">
@@ -32,17 +34,20 @@
         <div class="ui-g-12 ui-md-3 ui-lg-3 help-menu">
           <ul class="links">
 
-            <li class="links" [ngClass]="{'current':currentView === 'how-advanced-search'}" (click)="navigateToPage('how-advanced-search')"><a>Advanced Search Builder</a> <br>
+            <li class="links" [ngClass]="{'current':currentView === 'how-advanced-search'}"
+              (click)="navigateToPage('how-advanced-search')"><a>Advanced Search Builder</a> <br>
               <span class="description"> Using the Advanced Search Builder</span>
             </li>
-            <li class="links" [ngClass]="{'current':currentView === 'search-syntax'}"  (click)="navigateToPage('search-syntax')"><a>Search Syntax</a> <br>
+            <li class="links" [ngClass]="{'current':currentView === 'search-syntax'}"
+              (click)="navigateToPage('search-syntax')"><a>Search Syntax</a> <br>
               <span class="description"> Syntax Rules for Search </span>
             </li>
             <!--          <li class="links"><a> FAQ</a> <br>
                         <span class="description"> Frequently Asked Questions </span>
                       </li>
                     -->
-            <li class="links" [ngClass]="{'current':currentView === 'app-contact-us'}"  (click)="navigateToPage('app-contact-us')"><a> Contact Us</a> <br>
+            <li class="links" [ngClass]="{'current':currentView === 'app-contact-us'}"
+              (click)="navigateToPage('app-contact-us')"><a> Contact Us</a> <br>
               <span class="description"> Site Feedback and Support</span>
             </li>
           </ul>
@@ -53,7 +58,7 @@
             <how-advanced-search></how-advanced-search>
           </div>
           <div *ngSwitchCase="currentView === 'search-syntax'">
-             <search-syntax></search-syntax>
+            <search-syntax></search-syntax>
           </div>
           <div *ngSwitchCase="currentView === 'app-contact-us'">
             <app-contact-us></app-contact-us>

--- a/angular/src/app/policy/policy.component.html
+++ b/angular/src/app/policy/policy.component.html
@@ -11,11 +11,13 @@
     top.location = self.location;
   }
 </script>
-
+<script async type="text/javascript" id="_fed_an_ua_tag"
+  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
 
 <div class="ui-g" style="width: 100%;background-color: #153971;color: #FFFFFF">
   <div class="ui-g-12" style="padding-left:2.5em;padding-right: 2.5em;padding-top: 2.5em;">
-    <label id='title' style="font-size: xx-large;float: left;display: block;"><i class="faa faa-book faa-lg"></i>Policy</label>
+    <label id='title' style="font-size: xx-large;float: left;display: block;"><i
+        class="faa faa-book faa-lg"></i>Policy</label>
     <ol class="breadcrumb" style="float: right;">
       <li><a href="#" style="color: #fff;">Home</a></li>
       <li class="active breadCrumb-text">About</li>
@@ -30,21 +32,21 @@
       <div class="ui-g-12 ui-md-6 ui-lg-6"
         style="font-family: Source Sans Pro,sans-serif;font-size:20px;line-height: 1.2em;">
         <div class="adv-step">
-            The NIST PDL and associated data are stored in NIST’s public data repository. Please refer to the <a
-              href="https://www.nist.gov/open" target="_blank">NIST Open Data</a> website for additional organizational
-            policy and related NIST directive information.
+          The NIST PDL and associated data are stored in NIST’s public data repository. Please refer to the <a
+            href="https://www.nist.gov/open" target="_blank">NIST Open Data</a> website for additional organizational
+          policy and related NIST directive information.
         </div>
         <div class="adv-step">
-            In accordance with U.S. Government Open Data Policy and the <a
-              href="https://www.nist.gov/sites/default/files/documents/2017/04/28/NIST-Plan-for-Public-Access.pdf"
-              target="_blank">NIST Plan for Providing Public Access to the Results of Federally Funded Research</a>,
-            NIST
-            maintains a publicly accessible inventory of available data, the NIST Public Data Listing (PDL). This online
-            inventory is harvested by the Department of Commerce and made publicly available at <a
-              href="https://data.gov/" target="_blank">Data.gov</a>. These NIST PDL complies with the guidance set forth
-            in OMB M-13-13 policy and uses the <a href="https://project-open-data.cio.gov/" target="_blank">Project Open
-              Data</a> standard metadata schema representation.
-         </div>
+          In accordance with U.S. Government Open Data Policy and the <a
+            href="https://www.nist.gov/sites/default/files/documents/2017/04/28/NIST-Plan-for-Public-Access.pdf"
+            target="_blank">NIST Plan for Providing Public Access to the Results of Federally Funded Research</a>,
+          NIST
+          maintains a publicly accessible inventory of available data, the NIST Public Data Listing (PDL). This online
+          inventory is harvested by the Department of Commerce and made publicly available at <a
+            href="https://data.gov/" target="_blank">Data.gov</a>. These NIST PDL complies with the guidance set forth
+          in OMB M-13-13 policy and uses the <a href="https://project-open-data.cio.gov/" target="_blank">Project Open
+            Data</a> standard metadata schema representation.
+        </div>
         <div class="adv-step">
           <p>
             NIST’s public data repository records are accessible in machine-readable open data formats and demonstrate

--- a/angular/src/app/policy/policy.component.html
+++ b/angular/src/app/policy/policy.component.html
@@ -11,8 +11,6 @@
     top.location = self.location;
   }
 </script>
-<script async type="text/javascript" id="_fed_an_ua_tag"
-  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
 
 <div class="ui-g" style="width: 100%;background-color: #153971;color: #FFFFFF">
   <div class="ui-g-12" style="padding-left:2.5em;padding-right: 2.5em;padding-top: 2.5em;">

--- a/angular/src/app/search/search.component.html
+++ b/angular/src/app/search/search.component.html
@@ -12,11 +12,6 @@
   }
 </script>
 
-<head>
-  <script async type="text/javascript" id="_fed_an_ua_tag"
-    src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
-</head>
-
 <div class="ui-fluid searchColor">
   <div class="ui-g">
     <div class="ui-g-12 background-gray">

--- a/angular/src/index.html
+++ b/angular/src/index.html
@@ -25,6 +25,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
+    <script async type="text/javascript" id="_fed_an_ua_tag"
+    src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
+    
 </head>
 <body style="background-color: #000">
   <sdp-app>


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-773

The reason that SDP didn't "phone home" was that I didn't add that piece of Google Analyst code to index.html. I also added the code to help, about and policy page (the search page already has it).

This should make it work as before. But it's not fully functioning with SPA. When navigating to search, about, policy or help page, GA function will not triggered unless user refresh the pages. This will be fixed once I figure out how to use the GA function provided by DAP and apply it to router event.

This review just need to confirm that when open SDP home page, or you refresh search, about, policy or help page, "analytics.js" should show up in "Network" tab in the Chrome Developer Tools.