### PR TITLE
ODD-733 Part 2: Fix Google Analytics support for our SPA

### DIFF
--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -83,7 +83,6 @@ export class AppComponent implements AfterViewInit {
 
 
   removeItem(row:any) {
-    console.log("row" + JSON.stringify(row));
     let dataId: any;
     // convert the map to an array
     let delRow = this.searchEntities.indexOf(row);

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 import { environment } from '../environments/environment';
 import { RealModule } from '../app/real.module';
 import {enableProdMode} from '@angular/core';
+import {GoogleAnalyticsService} from "./shared/ga-service/google-analytics.service";
 
 /**
  * Initialize the configs for backend services
@@ -78,6 +79,7 @@ enableProdMode();
   ],
   providers: [
     HttpClientModule,
+    GoogleAnalyticsService,
     {
       provide: APP_INITIALIZER,
       useFactory: appInitializerFn,
@@ -92,4 +94,6 @@ enableProdMode();
   bootstrap: [AppComponent],
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
 })
-export class AppModule { }
+export class AppModule { 
+  constructor(protected _googleAnalyticsService: GoogleAnalyticsService) { } // We inject the service here to keep it alive whole time
+}

--- a/angular/src/app/can-deactivate/component-can-deactivate.ts
+++ b/angular/src/app/can-deactivate/component-can-deactivate.ts
@@ -6,7 +6,6 @@ export abstract class ComponentCanDeactivate {
 
     @HostListener('window:beforeunload', ['$event'])
     unloadNotification($event: any) {
-        console.log("I am here! ");
         if (!this.canDeactivate()) {
             $event.returnValue =true;
         }

--- a/angular/src/app/form-can-deactivate/form-can-deactivate.ts
+++ b/angular/src/app/form-can-deactivate/form-can-deactivate.ts
@@ -6,8 +6,6 @@ export abstract class FormCanDeactivate extends ComponentCanDeactivate{
  abstract get dataChanged():boolean;
  
  canDeactivate():boolean{
-     console.log("this.dataChanged: ");
-     console.log(this.dataChanged);
      return !this.dataChanged;
   }
 }

--- a/angular/src/app/help/help.component.html
+++ b/angular/src/app/help/help.component.html
@@ -11,8 +11,6 @@
     top.location = self.location;
   }
 </script>
-<script async type="text/javascript" id="_fed_an_ua_tag"
-  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
 
 <div class="sdp-help-page">
   <div class="ui-g" style="width: 100%;background-color: #153971;color: #FFFFFF">

--- a/angular/src/app/home/home.component.ts
+++ b/angular/src/app/home/home.component.ts
@@ -79,13 +79,11 @@ export class HomeComponent implements OnInit {
 
     this.SDPAPI = this.confValues.SDPAPI;
     this. imageURL = this.confValues.SDPAPI + 'assets/images/front-image.jpg';
-    console.log(this. imageURL);
     this.getTaxonomies();
     this.getTaxonomySuggestions();
     this.getSearchFields();
     this.rows = [{}];
     this.searchOperators();
-    console.log("taxonomy" + JSON.stringify(this.suggestedTaxonomies));
     var placeHolder = ['Kinetics database', 'Gallium', '"SRD 101"', 'XPDB', 'Interatomic Potentials'];
     var n = 0;
     var loopLength = placeHolder.length;
@@ -102,7 +100,6 @@ export class HomeComponent implements OnInit {
    * Set the display to show the examples dialog
    */
   toggleTextRotate() {
-    console.log("hello" + this.textRotate);
     if (this.searchValue == "") {
       this.textRotate = !this.textRotate;
     }

--- a/angular/src/app/search/search.component.ts
+++ b/angular/src/app/search/search.component.ts
@@ -180,8 +180,6 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
     if (_.isEmpty(queryName)) {
       this.queryNameReq = true;
     } else {
-      console.log("query name--" + queryName);
-      console.log("query value--" + this.searchValue);
       this.getSearchQueryList();
       this.duplicateQuery = false;
       for (let resultItem of this.searchEntities) {
@@ -475,8 +473,6 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
     this.status = (<any>error).httpStatus;
     this.msgs.push({ severity: 'error', summary: this.errorMsg + ':', detail: this.status + ' - ' + this.exception });
     this.searching = false;
-    console.log("Search value: " + this.searchValue);
-    console.log("Search error: " + this.errorMsg + ': ' + this.status + ' - ' + this.exception);
   }
 
   showMoreResTopics() {
@@ -1440,7 +1436,7 @@ export class SearchPanelComponent implements OnInit, OnDestroy {
       this.getTaxonomies();
 
       this.doSearch(this.searchValue, this.searchTaxonomyKey, this.queryAdvSearch);
-      console.log('authors inside init: ' + params['authors']);
+      // console.log('authors inside init: ' + params['authors']);
     });
   }
 

--- a/angular/src/app/shared/ga-service/google-analytics.service.spec.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { GoogleAnalyticsService } from './google-analytics.service';
+
+describe('GoogleAnalyticsService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [GoogleAnalyticsService]
+    });
+  });
+
+  it('should be created', inject([GoogleAnalyticsService], (service: GoogleAnalyticsService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/angular/src/app/shared/ga-service/google-analytics.service.spec.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.spec.ts
@@ -1,15 +1,21 @@
 import { TestBed, inject } from '@angular/core/testing';
 
 import { GoogleAnalyticsService } from './google-analytics.service';
+import { RouterModule } from '@angular/router';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('GoogleAnalyticsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterModule, RouterTestingModule],
       providers: [GoogleAnalyticsService]
     });
   });
 
-  it('should be created', inject([GoogleAnalyticsService], (service: GoogleAnalyticsService) => {
+  it('should be created', () => {
+    const service: GoogleAnalyticsService = TestBed.get(GoogleAnalyticsService);
+
     expect(service).toBeTruthy();
-  }));
+  });
 });

--- a/angular/src/app/shared/ga-service/google-analytics.service.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.ts
@@ -8,7 +8,9 @@ export class GoogleAnalyticsService {
   constructor(router: Router) {
     router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
-        gas('send', 'pageview', event.url, 'pageview');
+        setTimeout(() => {
+          gas('send', 'pageview', event.url, 'pageview');
+        }, 1000);
       }
     })
   }

--- a/angular/src/app/shared/ga-service/google-analytics.service.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import {Router, NavigationEnd} from '@angular/router';
+import { environment } from '../../../environments/environment';
+declare var gas:Function; 
+
+@Injectable()
+export class GoogleAnalyticsService {
+  constructor(router: Router) {
+    router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        gas('send', 'pageview', event.url, 'pageview');
+      }
+    })
+  }
+}

--- a/angular/src/app/shared/search-query/search-query.service.ts
+++ b/angular/src/app/shared/search-query/search-query.service.ts
@@ -125,14 +125,10 @@ export class SearchQueryService {
     // convert the map to an array
     for (let key in myCartMap) {
       let value = myCartMap[key];
-      console.log("status before" + JSON.stringify(value.data.downloadStatus));
       if (value.data.downloadedStatus == null ) {
-        console.log("status after" + JSON.stringify(value.data.downloadStatus));
-        console.log("value" + JSON.stringify(value.data.resId));
         searchEntities.push(value);
       }
     }
-    console.log("cart" + JSON.stringify(searchEntities));
     let cartMap = searchEntities.reduce(function(map, cartEntry, i) {
       map[cartEntry.data.id] = cartEntry;
       return map;
@@ -164,12 +160,12 @@ export class SearchQueryService {
 
   setQueryLength(value: number) {
     this.storageSub.next(value);
-    console.log("query size inside method: " + this.storageSub.getValue());
+    // console.log("query size inside method: " + this.storageSub.getValue());
   }
 
   setAdvQueryLength(value: number) {
     this.storageAdvSub.next(value);
-    console.log("cart size inside method: " + this.storageAdvSub.getValue());
+    // console.log("cart size inside method: " + this.storageAdvSub.getValue());
   }
 
   /**

--- a/angular/src/app/shared/search-service/search-service.service.real.ts
+++ b/angular/src/app/shared/search-service/search-service.service.real.ts
@@ -88,7 +88,6 @@ export class RealSearchService implements SearchService{
       searchPhraseValue = '&';
     }
 
-    console.log('url: ' + this.RMMAPIURL + 'records?' + searchPhraseValue + 'topic.tag=' + searchTaxonomyKey);
     return this.http.get(this.RMMAPIURL + 'records?' + searchPhraseValue + 'topic.tag=' + searchTaxonomyKey);
   }
 

--- a/angular/src/app/shared/shared.module.ts
+++ b/angular/src/app/shared/shared.module.ts
@@ -12,8 +12,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { InputTextModule, DropdownModule, ButtonModule, SplitButtonModule, MenubarModule,
  PanelModule, DataTableModule, DialogModule, AutoCompleteModule, MultiSelectModule,
  PaginatorModule, CalendarModule, TabViewModule } from 'primeng/primeng';
-import { ConfirmationDialogService } from './confirmation-dialog/confirmation-dialog.service'
-
+import { ConfirmationDialogService } from './confirmation-dialog/confirmation-dialog.service';
 
 /**
  * Do not specify providers for modules that might be imported by a lazy loaded module.

--- a/angular/src/index.html
+++ b/angular/src/index.html
@@ -1,11 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <style id="antiClickjack">
     body {
       display: none !important;
     }
   </style>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>NIST Data Repository Page</title>
+  <link rel="shortcut icon" type="image/png" href="/assets/images/favicon.ico">
+  <meta name="description"
+    content="The home of the NIST science data discovery for public datasets. Explore and access data resources generated from Science, Engineering, and Technology research.">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="google-signin-client_id"
+    content="1019840961407-1m4qbsusbf3m5mi5jmoo08v1c02032j3.apps.googleusercontent.com">
+  <meta name="google-signin-scope" content="https://www.googleapis.com/auth/analytics.readonly">
+
   <script type="text/javascript">
     if (self === top) {
       var antiClickjack = document.getElementById("antiClickjack");
@@ -15,26 +31,17 @@
     }
   </script>
 
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>NIST Data Repository Page</title>
-  <link rel="shortcut icon" type="image/png" href="/assets/images/favicon.ico">
-  <meta name="description" content="The home of the NIST science data discovery for public datasets. Explore and access data resources generated from Science, Engineering, and Technology research.">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+  <script async type="text/javascript" id="_fed_an_ua_tag"
+    src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c">
+    </script>
 
-    <script async type="text/javascript" id="_fed_an_ua_tag"
-    src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c"></script>
-    
 </head>
+
 <body style="background-color: #000">
   <sdp-app>
   </sdp-app>
   // Fixes undefined module function in SystemJS bundle
   function module() {}
-  </script>
 
   <!-- shims:js -->
   <!-- endinject -->
@@ -50,4 +57,5 @@
   <!-- endinject -->
 
 </body>
+
 </html>

--- a/angular/src/index.html
+++ b/angular/src/index.html
@@ -18,9 +18,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="google-signin-client_id"
-    content="1019840961407-1m4qbsusbf3m5mi5jmoo08v1c02032j3.apps.googleusercontent.com">
-  <meta name="google-signin-scope" content="https://www.googleapis.com/auth/analytics.readonly">
 
   <script type="text/javascript">
     if (self === top) {
@@ -33,7 +30,7 @@
 
   <script async type="text/javascript" id="_fed_an_ua_tag"
     src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c">
-    </script>
+  </script>
 
 </head>
 


### PR DESCRIPTION
This completes the task [ODD-733](http://mml.nist.gov:8080/browse/ODD-773) started with PR #206 fix our support for Google Analytics (GA) in the SDP.  That previous PR partially enabled GA communications when the SDP single-page application (SPA) is first retrieved from the server; however, accessing different pages of the SPA (e.g. About, etc.) which doesn't involve further retrieval from the server would not trigger corresponding GA communications.  This PR enables support for access to different pages via the SPA.  

This has been tested on oardev and verified by @chuanlin2018 and Peter Linstrom.  