### PR TITLE
fixed dup page views

### DIFF
--- a/angular/src/app/shared/ga-service/google-analytics.service.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.ts
@@ -1,13 +1,19 @@
+// Google Analytics (GA) script was handled differently from traditional web pages. Angular 2+ is a SPA
+// which was considered only one page.
+// When GA script was first added to index.html, it analyzed index.html page to decide what element to listen.
+// In this all, index.html is very simple. There is nothing to listen but the home route '/'. 
+// So when home route is added to the page it later it will trigger this router event. 
+// We need to skip '/' to avoid registaer dup listeners.
+
 import { Injectable } from '@angular/core';
 import {Router, NavigationEnd} from '@angular/router';
-import { environment } from '../../../environments/environment';
 declare var gas:Function; 
 
 @Injectable()
 export class GoogleAnalyticsService {
   constructor(router: Router) {
     router.events.subscribe(event => {
-      if (event instanceof NavigationEnd) {
+      if (event instanceof NavigationEnd && event.url != '/') {
         setTimeout(() => {
           gas('send', 'pageview', event.url, 'pageview');
         }, 1000);


### PR DESCRIPTION
whenever user visits SDP home page, GA generates two page views instead of one. It was because '/' already watched when GA script was first added in index.html.

In this fix I filtered '/' in the router event.