### PR TITLE
Adjust build parameter to reduce package size.

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --aot --port 5555",
-    "build": "ng build --aot",
+    "build": "ng build --prod --aot --vendor-chunk --common-chunk --delete-output-path --buildOptimizer",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
@@ -44,7 +44,7 @@
     "zone.js": "~0.8.26"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.13.10",
+    "@angular-devkit/build-angular": "^0.13.10",
     "@angular/cli": "~6.0.0",
     "@angular/compiler-cli": "^7.2.12",
     "@angular/language-service": "^6.1.0",


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-833
Start up performance for SDP 

This is the first step of start up performance improvement. I added some parameters to build command to reduce the distribution page size.

In my local test, the fix reduced the package size from 32.4MB to 13.8MB.

Removing Ultima should further reduce the package size. But I will create a separate branch for it.

I this change I also changed "@angular-devkit/build-angular": "0.13.10" to "@angular-devkit/build-angular": "^0.13.10". Adding "^" is allow updating patch and minor releases: 0.13.11, 0.14.0 and so on.
