### PR TITLE
Fixed SRDs link

### DIFF
--- a/angular/src/app/top-menu-bar/top-menu-bar.component.html
+++ b/angular/src/app/top-menu-bar/top-menu-bar.component.html
@@ -41,7 +41,7 @@
         </ul>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://www.nist.gov/node/429021" target='_blank'>Standard Reference Data (SRDs) </a>
+        <a class="nav-link" href="https://www.nist.gov/srd" target='_blank'>Standard Reference Data (SRDs) </a>
       </li>
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown"


### PR DESCRIPTION
Fixed the SRD link in the top menu to point to https://www.nist.gov/srd.