### PR TITLE
Fixed filter clean up on a new search

### DIFF
--- a/angular/src/app/search/filters/filters.component.ts
+++ b/angular/src/app/search/filters/filters.component.ts
@@ -131,8 +131,6 @@ export class FiltersComponent implements OnInit, AfterViewInit {
     ngOnInit() {
         this.msgs = [];
         this.searchResultsError = [];
-
-        this.getFields();
     }
 
     /**

--- a/angular/src/app/search/filters/filters.component.ts
+++ b/angular/src/app/search/filters/filters.component.ts
@@ -95,7 +95,6 @@ export class FiltersComponent implements OnInit, AfterViewInit {
     errorMessage: string;
     exception: string;
     errorMsg: string;
-    inited: boolean = false;
 
     @Input() searchValue: string;
     @Input() searchTaxonomyKey: string;
@@ -118,7 +117,7 @@ export class FiltersComponent implements OnInit, AfterViewInit {
      * @param changes - changed detected
      */
     ngOnChanges(changes: SimpleChanges) {
-        if(this.inited && changes.searchValue != undefined && changes.searchValue != null){
+        if(changes.searchValue != undefined && changes.searchValue != null){
             if (changes.searchValue.currentValue != changes.searchValue.previousValue || 
                 changes.searchTaxonomyKey.currentValue != changes.searchTaxonomyKey.previousValue) {
 
@@ -134,7 +133,6 @@ export class FiltersComponent implements OnInit, AfterViewInit {
         this.searchResultsError = [];
 
         this.getFields();
-        this.inited = true;
     }
 
     /**


### PR DESCRIPTION
Issue: when user checked one/more filter item then switched to advanced search page and did a search, the filters in the UI appeared to be cleared but the result was still filtered.

Solution: removed "inited" variable that was initially used to prevent the data been loaded twice. And remove the getFields() function from ngOnInit. Confirmed that getFields() always got called from onOnChange when user conducted a new search.

To test: run local docker. Or run npm start and test it in localhost:5555.