### PR TITLE
remove unused package, jspdf, as a dependency

### DIFF
--- a/angular/angular.json
+++ b/angular/angular.json
@@ -36,7 +36,6 @@
               "src/styles.css"
             ],
             "scripts": [
-              "node_modules/jspdf/dist/jspdf.es.min.js",
               "node_modules/primeui/primeui-ng-all.min.js"
             ],
             "vendorChunk": true,
@@ -122,7 +121,6 @@
             ],
             "scripts": [
               "node_modules/lodash/lodash.min.js",
-              "node_modules/jspdf/dist/jspdf.min.js",
               "node_modules/primeui/primeui-ng-all.min.js"
             ],
             "assets": [

--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -1802,6 +1802,7 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
       "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -2207,12 +2208,6 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
       "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
       "dev": true
-    },
-    "@types/raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
-      "optional": true
     },
     "@types/retry": {
       "version": "0.12.1",
@@ -2738,7 +2733,8 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "autoprefixer": {
       "version": "10.4.2",
@@ -2896,12 +2892,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "optional": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -3091,11 +3081,6 @@
         "https-proxy-agent": "^2.2.1"
       }
     },
-    "btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
-    },
     "buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -3224,30 +3209,6 @@
       "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
       "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
       "dev": true
-    },
-    "canvg": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
-      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
-      "optional": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@types/raf": "^3.4.0",
-        "core-js": "^3.8.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.7",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^6.0.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.22.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.4.tgz",
-          "integrity": "sha512-1uLykR+iOfYja+6Jn/57743gc9n73EWiOnSJJ4ba3B4fOEYDBv25MagmEZBxTp5cWq4b/KPx/l77zgsp28ju4w==",
-          "optional": true
-        }
-      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -3856,15 +3817,6 @@
         "postcss-selector-parser": "^6.0.8"
       }
     },
-    "css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "optional": true,
-      "requires": {
-        "utrie": "^1.0.2"
-      }
-    },
     "css-loader": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.5.1.tgz",
@@ -4219,12 +4171,6 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
-    },
-    "dompurify": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.6.tgz",
-      "integrity": "sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg==",
-      "optional": true
     },
     "domutils": {
       "version": "2.8.0",
@@ -4861,11 +4807,6 @@
         "pend": "~1.2.0"
       }
     },
-    "fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
-    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -5333,16 +5274,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "optional": true,
-      "requires": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      }
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -6179,28 +6110,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
-    },
-    "jspdf": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.3.1.tgz",
-      "integrity": "sha512-1vp0USP1mQi1h7NKpwxjFgQkJ5ncZvtH858aLpycUc/M+r/RpWJT8PixAU7Cw/3fPd4fpC8eB/Bj42LnsR21YQ==",
-      "requires": {
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
-        "canvg": "^3.0.6",
-        "core-js": "^3.6.0",
-        "dompurify": "^2.2.0",
-        "fflate": "^0.4.8",
-        "html2canvas": "^1.0.0-rc.5"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.22.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.4.tgz",
-          "integrity": "sha512-1uLykR+iOfYja+6Jn/57743gc9n73EWiOnSJJ4ba3B4fOEYDBv25MagmEZBxTp5cWq4b/KPx/l77zgsp28ju4w==",
-          "optional": true
-        }
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -7660,7 +7569,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
@@ -8613,15 +8523,6 @@
         "fast-diff": "1.1.2"
       }
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "optional": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8741,7 +8642,8 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -8947,12 +8849,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
-    },
-    "rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0=",
-      "optional": true
     },
     "rimraf": {
       "version": "2.6.3",
@@ -9575,12 +9471,6 @@
         "minipass": "^3.1.1"
       }
     },
-    "stackblur-canvas": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
-      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
-      "optional": true
-    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -9746,12 +9636,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
-    "svg-pathdata": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-      "optional": true
-    },
     "symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -9904,15 +9788,6 @@
             "path-is-absolute": "^1.0.0"
           }
         }
-      }
-    },
-    "text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "optional": true,
-      "requires": {
-        "utrie": "^1.0.2"
       }
     },
     "text-table": {
@@ -10239,15 +10114,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
-    },
-    "utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "optional": true,
-      "requires": {
-        "base64-arraybuffer": "^1.0.2"
-      }
     },
     "uuid": {
       "version": "3.3.2",

--- a/angular/package.json
+++ b/angular/package.json
@@ -33,7 +33,6 @@
     "core-js": "^2.5.4",
     "font-awesome": "^4.7.0",
     "jasmine": "^2.8.0",
-    "jspdf": "^2.3.1",
     "lodash-es": "^4.17.21",
     "ngx-pagination": "^3.2.1",
     "ngx-toastr": "^12.0.0",

--- a/angular/package.json
+++ b/angular/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 5555",
-    "build": "ng build --configuration production --aot --vendor-chunk --common-chunk --delete-output-path --buildOptimizer",
+    "build": "ng build --configuration production --aot --vendor-chunk --common-chunk --delete-output-path --build-optimizer",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",


### PR DESCRIPTION
It appears something went wrong with the merge of #254 which fixes a security issue with a package dependency, [jspdf](https://www.npmjs.com/package/jspdf); after the merge, the unit tests fail with the same build error documented in #254.  This was due to another `scripts` entry in the `angular.json` file that needed to be updated.  After making that fix, I found that unit tests were still failing but for a different reason.  

I noticed that jspdf is included as a code dependency (not a build dependency) but does not appear to be used anywhere in our code.  I am therefore recommending that we remove this package as a dependency.  Doing so allows unit tests to pass and the distributions to build.  