### PR TITLE
Fix/filters dropdown etc

### DIFF
--- a/angular/src/app/search/filters/filters.component.css
+++ b/angular/src/app/search/filters/filters.component.css
@@ -99,8 +99,7 @@
 
 .filter-checkbox {
     width: 100%;
-    min-width: 400px;
-    overflow: auto;
+    overflow-x: hidden;
 }
 
 .bottom-line {
@@ -121,3 +120,10 @@
 	white-space: nowrap !important;
 }
 
+.text-nowrap {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+    width: 100%;
+    min-width: 1px;
+}

--- a/angular/src/app/search/filters/filters.component.html
+++ b/angular/src/app/search/filters/filters.component.html
@@ -1,17 +1,14 @@
-<div [ngStyle]="{'width': filterWidthNum+'px'}">
+<div [@filterExpand]="isActive? 'expanded' : 'collapsed'" [ngStyle]="{'width': mobileMode? '100%': filterWidthNum+'px'}">
     <div class="normalFilter" [hidden]="!isActive && !mobileMode" id="activeFilter" style="height:auto;padding-bottom: 1em;">
         <div style="padding: 0px;">
             <!-- Filter header -->
             <div id="filterHeader" *ngIf="isActive || mobileMode">
-                <a id="filtersLabel">Filters </a> <a
-                    class="btn-sm collapsed in" (click)="setColumnWidth()" data-toggle="collapse"
-                    style="border-color: #025277; color: #FFF;padding: 0em;border: 0em"
-                    data-target="#demo"><i [ngClass]="getFilterImgClass()"
-                        style="zoom: 100%;color: #fff;cursor: pointer;"></i></a>
-                <a href="#" id="clear-all"
+                <a id="filtersLabel" (click)="setFilterWidth()" data-toggle="collapse" title="Collapse filter" data-target="#demo"><span *ngIf="filterWidthNum > 170">Filters </span><i class="faa faa-angle-double-left filterIcon"></i></a>
+
+                <a href="#" id="clear-all" data-toggle="tooltip" title="Clear all filters"
                     (click)="$event.preventDefault();clearFilters()">
                     <i style="vertical-align: middle;zoom: 70%;margin-right: .3em;" class="faa faa-remove">
-                    </i>Clear All</a>
+                    </i><span *ngIf="filterWidthNum > 170">Clear All</span></a>
             </div>
 
             <!-- Filter body -->
@@ -20,7 +17,7 @@
                 <i class="faa faa-spinner faa-spin faa-stack-2x" style="color:#1E6BA1;" aria-hidden="true"></i>
             </div>
 
-            <div style="padding-left: .5em;overflow: hidden;" *ngIf="isActive && !searching">
+            <div style="padding-left: .5em;" *ngIf="isActive && !searching">
                 <!-- NIST Research topics -->
                 <div class="bottom-line">
                     <div class="filter-checkbox">
@@ -31,14 +28,16 @@
                                 (onNodeExpand)="showMoreLink = true; nodeExpanded = true"
                                 (onNodeCollapse)="nodeExpanded = false">
                                 <ng-template let-node pTemplate="default">
-                                    <span *ngIf="node.label.split('-')[1] !=''; else header1" class="invisible-scrollbar"> {{node.label.split("-")[0]}}&nbsp;</span>
-                                    <ng-template #header1>
-                                        <span><b> {{node.label.split("-")[0]}}&nbsp;</b></span>
-                                    </ng-template>
+                                    <div class="text-nowrap" data-toggle="tooltip" [title]="filterTooltip(node)">
+                                        <span *ngIf="node.label.split('-')[1] !=''; else header1" class="invisible-scrollbar"> {{node.label.split("-")[0]}}&nbsp;</span>
+                                        <ng-template #header1>
+                                            <span><b> {{node.label.split("-")[0]}}&nbsp;</b></span>
+                                        </ng-template>
 
-                                    <span class="w3-badge badge1"
-                                        style="background-color: #1471AE" *ngIf="node.label.split('-')[1] !=''">
-                                        {{node.label.split("-")[1]}}</span>
+                                        <span class="w3-badge badge1"
+                                            style="background-color: #1471AE" *ngIf="node.label.split('-')[1] !=''">
+                                            {{node.label.split("-")[1]}}</span>
+                                    </div>
                                 </ng-template>
                             </p-tree>
                         </div>
@@ -55,7 +54,7 @@
                     <span class="show-more-less" style="float: right;" (click)="toggleMoreOptions()">{{moreOptionsText}}</span>
                 </div>
 
-                <div style="overflow:auto; width: 100%;">
+                <div style="width: 100%;">
                     <div [@expandOptions]="MoreOptionsDisplayed ? 'collapsed':'expanded'">
                         <!-- Resource type -->
                         <div class="filter-checkbox bottom-line">
@@ -64,14 +63,16 @@
                                 (onNodeUnselect)="filterResults()"
                                 (onNodeSelect)="filterResults()">
                                 <ng-template let-node pTemplate="default">
-                                    <span *ngIf="node.label.split('-')[1] !=''; else header2"> {{node.label.split("-")[0]}}&nbsp;</span>
-                                    <ng-template #header2>
-                                        <span><b> {{node.label.split("-")[0]}}&nbsp;</b></span>
-                                    </ng-template>
+                                    <div class="text-nowrap" data-toggle="tooltip" [title]="filterTooltip(node)">
+                                        <span *ngIf="node.label.split('-')[1] !=''; else header2"> {{node.label.split("-")[0]}}&nbsp;</span>
+                                        <ng-template #header2>
+                                            <span><b> {{node.label.split("-")[0]}}&nbsp;</b></span>
+                                        </ng-template>
 
-                                    <span class="w3-badge badge1" style="background-color: #1471AE;"
-                                        *ngIf="node.label.split('-')[1] !=''">
-                                        {{node.label.split("-")[1]}}</span>
+                                        <span class="w3-badge badge1" style="background-color: #1471AE;"
+                                            *ngIf="node.label.split('-')[1] !=''">
+                                            {{node.label.split("-")[1]}}</span>
+                                    </div>
                                 </ng-template>
                             </p-tree>
                         </div>
@@ -82,14 +83,16 @@
                                 [(selection)]="selectedComponentsNode" (onNodeUnselect)="filterResults()"
                                 (onNodeSelect)="filterResults()">
                                 <ng-template let-node pTemplate="default">
-                                    <span *ngIf="node.label.split('-')[1] !=''; else header3"> {{node.label.split("-")[0]}}&nbsp;</span>
-                                    <ng-template #header3>
-                                        <span><b> {{node.label.split("-")[0]}}&nbsp;</b></span>
-                                    </ng-template>
+                                    <div class="text-nowrap" data-toggle="tooltip" [title]="filterTooltip(node)">
+                                        <span *ngIf="node.label.split('-')[1] !=''; else header3"> {{node.label.split("-")[0]}}&nbsp;</span>
+                                        <ng-template #header3>
+                                            <span><b> {{node.label.split("-")[0]}}&nbsp;</b></span>
+                                        </ng-template>
 
-                                    <span class="w3-badge badge1" style="background-color: #1471AE"
-                                        *ngIf="node.label.split('-')[1] !=''">
-                                        {{node.label.split("-")[1]}}</span>
+                                        <span class="w3-badge badge1" style="background-color: #1471AE"
+                                            *ngIf="node.label.split('-')[1] !=''">
+                                            {{node.label.split("-")[1]}}</span>
+                                    </div>
                                 </ng-template>
                             </p-tree>
                         </div>
@@ -129,15 +132,17 @@
                             inputId="keyword" 
                             [(ngModel)]="selectedKeywords"
                             [suggestions]="suggestedKeywords" 
-                            (completeMethod)="filterKeywords($event)"
+                            (completeMethod)="updateSuggestedKeywords($event)"
                             [multiple]="true" 
                             (onSelect)="filterResults()"
                             (onUnselect)="filterResults()" 
                             [minLength]="1"
                             [maxlength]="30" 
                             [style]="filterStyle"
-                            [inputStyle]="{'width':'100%'}"
-                            class="p-autocomplete">
+                            [inputStyle]="{'width':'100%'}">
+                            <ng-template let-keyword pTemplate="item">
+                                <div data-toggle="tooltip" [title]="suggestedKeywordsLkup[keyword]">{{keyword}}</div>
+                            </ng-template>
                         </p-autoComplete>
                     </div>
                 </div>
@@ -145,16 +150,7 @@
         </div>
     </div>
 
-    <!-- <div *ngIf="!searching && !isActive && !mobileMode" class="collapsedFilter" 
-         [ngStyle]="{'height': comheight}">
-        
-        <div (click)="setColumnWidth()">
-            <i class="faa faa-angle-double-right" style="color: #fff;zoom: 130%"></i>
-            <div class="rotate rotatedFilter"> Filters </div>
-        </div>
-    </div> -->
-
-    <div *ngIf="!searching && !isActive && !mobileMode" class="collapsedFilterBox" (click)="setColumnWidth()">
+    <div *ngIf="!searching && !isActive && !mobileMode" class="collapsedFilterBox" (click)="setFilterWidth()">
         
         <!-- Collapsed filters -->
         <div >

--- a/angular/src/app/search/filters/filters.component.html
+++ b/angular/src/app/search/filters/filters.component.html
@@ -1,9 +1,13 @@
-<div [@filterExpand]="isActive? 'expanded' : 'collapsed'" [ngStyle]="{'width': mobileMode? '100%': filterWidthNum+'px'}">
+<div [@filterExpand]="mobileMode? 'expanded':isActive? 'expanded' : 'collapsed'" [ngStyle]="{'width': mobileMode? '100%': filterWidthNum+'px'}">
     <div class="normalFilter" [hidden]="!isActive && !mobileMode" id="activeFilter" style="height:auto;padding-bottom: 1em;">
         <div style="padding: 0px;">
             <!-- Filter header -->
             <div id="filterHeader" *ngIf="isActive || mobileMode">
-                <a id="filtersLabel" (click)="setFilterWidth()" data-toggle="collapse" title="Collapse filter" data-target="#demo"><span *ngIf="filterWidthNum > 170">Filters </span><i class="faa faa-angle-double-left filterIcon"></i></a>
+                <a id="filtersLabel"
+                class="btn-sm collapsed in" (click)="setFilterWidth()" data-toggle="collapse"
+                style="border-color: #025277; color: #FFF;padding: 0em;border: 0em"
+                data-target="#demo"><span *ngIf="filterWidthNum > 170">Filters </span><i [ngClass]="getFilterImgClass()"
+                    style="zoom: 100%;color: #fff;cursor: pointer;"></i></a>
 
                 <a href="#" id="clear-all" data-toggle="tooltip" title="Clear all filters"
                     (click)="$event.preventDefault();clearFilters()">

--- a/angular/src/app/search/filters/filters.component.ts
+++ b/angular/src/app/search/filters/filters.component.ts
@@ -31,7 +31,7 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
         ]),
         trigger('filterExpand', [
             state('collapsed', style({width: '40px'})),
-            state('expanded', style({height: '*'})),
+            state('expanded', style({width: '*'})),
             transition('expanded <=> collapsed', animate('625ms'))
         ])
     ]

--- a/angular/src/app/search/filters/filters.component.ts
+++ b/angular/src/app/search/filters/filters.component.ts
@@ -17,22 +17,20 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
     providers: [TaxonomyListService, SearchfieldsListService],
     animations: [
         trigger('expand', [
-            state('collapsed', style({height: '183px'})),
-            state('expanded', style({height: '*'})),
-            transition('expanded <=> collapsed', animate('625ms'))
-        ]),
-        trigger('expand', [
             state('closed', style({height: '40px'})),
             state('collapsed', style({height: '183px'})),
+            state('expanded', style({height: '*'})),
+            transition('expanded <=> collapsed', animate('625ms')),
+            transition('expanded <=> closed', animate('625ms')),
             transition('closed <=> collapsed', animate('625ms'))
-        ]),
-        trigger('expand', [
-            state('closed', style({height: '40px'})),
-            state('expanded', style({height: '*'})),
-            transition('expanded <=> closed', animate('625ms'))
         ]),
         trigger('expandOptions', [
             state('collapsed', style({height: '0px'})),
+            state('expanded', style({height: '*'})),
+            transition('expanded <=> collapsed', animate('625ms'))
+        ]),
+        trigger('filterExpand', [
+            state('collapsed', style({width: '40px'})),
             state('expanded', style({height: '*'})),
             transition('expanded <=> collapsed', animate('625ms'))
         ])
@@ -43,6 +41,7 @@ export class FiltersComponent implements OnInit, AfterViewInit {
     searchResults: any[] = [];
     suggestedThemes: string[] = [];
     suggestedKeywords: string[] = [];
+    suggestedKeywordsLkup: any = {};
     suggestedAuthors: string[] = [];
     selectedAuthor: any[] = [];
     selectedKeywords: any[] = [];
@@ -104,6 +103,7 @@ export class FiltersComponent implements OnInit, AfterViewInit {
     nodeExpanded: boolean = true;
     comheight: string; // parent div height
     comwidth: string;  // parent div width
+    maxDropdownLabelLength: number = 30;
 
     filterStyle = {'width':'100%', 'background-color': '#FFFFFF','font-weight': '400','font-style': 'italic', 'font-family': 'sans-serif'};
 
@@ -473,7 +473,7 @@ export class FiltersComponent implements OnInit, AfterViewInit {
             lFilterString += "keyword=";
 
             for (let keyword of this.selectedKeywords) {
-                lFilterString += keyword + ",";
+                lFilterString += this.suggestedKeywordsLkup[keyword] + ",";
             }
         }
 
@@ -517,15 +517,44 @@ export class FiltersComponent implements OnInit, AfterViewInit {
 
     /**
      * Create a list of suggested keywords based on given search query
+     * Because some keywords might be very long, for display purpose we only show the first few words in
+     * the dropdown list.
+     * suggestedKeywords - for display
+     * suggestedKeywordsLkup - stores the real ketwords
      * @param event - search query that user typed into the keyword filter box
      */
-    filterKeywords(event: any) {
+     updateSuggestedKeywords(event: any) {
         let keyword = event.query;
+        let keywordAbbr: string;
         this.suggestedKeywords = [];
+        this.suggestedKeywordsLkup = {};
+
         for (let i = 0; i < this.keywords.length; i++) {
-            let keyw = this.keywords[i];
+            let keyw = this.keywords[i].trim();
             if (keyw.toLowerCase().indexOf(keyword.toLowerCase()) >= 0) {
-                this.suggestedKeywords.push(keyw);
+                //If the keyword length is greater than the maximum length, we want to truncate
+                //it so that the length is close the maximum length.
+                if(keyw.length > this.maxDropdownLabelLength){
+                    let wordCount = 1;
+                    while(keyw.split(' ', wordCount).join(' ').length < this.maxDropdownLabelLength) {
+                        wordCount++;
+                    }
+
+                    keywordAbbr = keyw.substring(0, keyw.split(' ', wordCount).join(' ').length);
+                    if(keywordAbbr.trim().length < keyw.length) keywordAbbr = keywordAbbr + "...";
+                }else    
+                    keywordAbbr = keyw;
+
+                let i = 1;
+                let tmpKeyword = keywordAbbr;
+                while(Object.keys(this.suggestedKeywordsLkup).indexOf(tmpKeyword) >= 0 && i < 100){
+                    tmpKeyword = keywordAbbr + "(" + i + ")";
+                    i++;
+                }
+                keywordAbbr = tmpKeyword;
+
+                this.suggestedKeywords.push(keywordAbbr);
+                this.suggestedKeywordsLkup[keywordAbbr] = keyw;
             }
         }
 
@@ -870,12 +899,24 @@ export class FiltersComponent implements OnInit, AfterViewInit {
      * Set the width of the filter column. If the filter is active, set the width to 25%. 
      * If the filter is collapsed, set the width to 40px.
      */
-    setColumnWidth() {
+     setFilterWidth() {
         this.isActive = !this.isActive;
         if (!this.isActive) {
             this.filterMode.emit("collapsed");
         } else {
             this.filterMode.emit('normal');
         }
+    }
+
+    /**
+     * Return tooltip text for given filter tree node.
+     * @param filternode tree node of a filter
+     * @returns tooltip text
+     */
+    filterTooltip(filternode: any) {
+        if(filternode && filternode.label)
+            return filternode.label.split('-')[0] + "-" + filternode.label.split('-')[1];
+        else
+            return "";
     }
 }

--- a/angular/src/app/search/results/results.component.ts
+++ b/angular/src/app/search/results/results.component.ts
@@ -106,7 +106,6 @@ export class ResultsComponent implements OnInit {
             if(!filter || this.currentFilter == filter) return;
  
             this.currentFilter = filter; 
-
             this.searchSubscription = this.search(null, null, this.itemsPerPage);
         }));
 
@@ -136,7 +135,6 @@ export class ResultsComponent implements OnInit {
                 this.currentFilter = "NoFilter";
                 this.currentSortOrder = "";
 
-                console.log("Search value", this.searchValue);
                 this.searchSubscription = this.search(null, 1, this.itemsPerPage);
             }
         }
@@ -246,7 +244,6 @@ export class ResultsComponent implements OnInit {
         return this.searchService.searchPhrase(query, searchTaxonomyKey, null, this.currentPage, pageSize, this.currentSortOrder, this.currentFilter)
         .subscribe(
             searchResults => {
-                console.log("searchResults", searchResults);
                 that.searchResults = searchResults.ResultData;
                 that.totalItems = searchResults.ResultCount;
                 that.resultStatus = this.RESULT_STATUS.success;

--- a/angular/src/app/search/search.component.ts
+++ b/angular/src/app/search/search.component.ts
@@ -125,13 +125,13 @@ export class SearchComponent implements OnInit, OnDestroy {
     updateWidth(filterMode?: string){
         this.filterMode = filterMode? filterMode : this.filterMode;
 
-        if(this.filterMode == 'normal'){
-            this.filterToggler = 'expanded';
-        }else{
-            this.filterToggler = 'collapsed';
-        }
-
         if(!this.mobileMode){
+            if(this.filterMode == 'normal'){
+                this.filterToggler = 'expanded';
+            }else{
+                this.filterToggler = 'collapsed';
+            }
+
             if(this.filterMode == 'normal'){
                 this.filterWidth = this.mobWidth / 4;
                 this.filterToggler = 'expanded';
@@ -143,7 +143,8 @@ export class SearchComponent implements OnInit, OnDestroy {
             this.filterWidthStr = this.filterWidth + 'px';
         }else{
             this.filterWidth = this.mobWidth;
-            this.filterWidthStr = "100%"
+            this.filterWidthStr = "100%";
+            this.filterToggler = 'expanded';
         }
 
         this.setResultWidth();


### PR DESCRIPTION
This check in did the following fixes:

1. Fixed keyword filter dropdown menu: set max length of each menu item for display.
2. Improved filters performance: made vertical scroll bars show up when user re-sizes the filter panel; Hide filter header bar text when filter panel becomes very narrow.
3. Kept filter header in mobile mode when user clicked on collapse button.