### PR TITLE
Treat semicolon as comma when parsing keywords

### DIFF
--- a/angular/src/app/search/filters/filters.component.ts
+++ b/angular/src/app/search/filters/filters.component.ts
@@ -758,12 +758,18 @@ export class FiltersComponent implements OnInit, AfterViewInit {
      */
     collectKeywords(searchResults: any[]) {
         let kwords: string[] = [];
+        let tempkeywords: string[] = [];
+
         for (let resultItem of searchResults) {
         if (resultItem.keyword && resultItem.keyword !== null && resultItem.keyword.length > 0) {
             for (let keyword of resultItem.keyword) {
-            if (kwords.indexOf(keyword) < 0) {
-                kwords.push(keyword);
-            }
+                //If keyword value contains semicolons, split them
+                tempkeywords = keyword.split(";");
+                for(let kw of tempkeywords) {
+                    if (kwords.indexOf(kw) < 0) {
+                        kwords.push(kw);
+                    }
+                }
             }
         }
         }


### PR DESCRIPTION
This is a quick fix. No Jira ticket associate with it.

Problem: Some keywords are separated by semicolons instead of comma. The app treated this kind of keywords as one. This caused problem in keyword filter that some suggested keywords were very long and some of them weren't searchable.

This fix treats semicolon the same as comma when parsing keywords.

To test, type in "3.5 GHz" in keyword filter box, make sure those semicolon separated keyword records are still show up.
![Screen Shot 2022-08-16 at 4 45 37 PM](https://user-images.githubusercontent.com/44069356/184981788-63a36ec3-9147-45fb-90b5-5a5147a0e115.png)

 