### PR TITLE
Fixed Customize View error

### DIFF
--- a/angular/src/app/shared/searchfields-list/searchfields-list.service.ts
+++ b/angular/src/app/shared/searchfields-list/searchfields-list.service.ts
@@ -32,10 +32,10 @@ export class SearchfieldsListService {
   get(): Observable<any> {
       return this.appConfig.getConfig().pipe(
           rxjsop.mergeMap((conf) => {
-              return this.http.get(conf.RMMAPI + 'taxonomy?level=1');
+              return this.http.get(conf.RMMAPI + 'records/fields');
           }),
           rxjsop.catchError((err) => {
-              console.error("Failed to download taxonomy: " + JSON.stringify(err));
+              console.error("Failed to download fields: " + JSON.stringify(err));
               return throwError(err);
           })
       );


### PR DESCRIPTION
This checkin fixed one problem for release 1.10. There is no Jira ticket for this.

Issue: All fields in Customize View dropdown were missing.

Root cause: for some reason the URL that pulls field list from server was replaced by taxonomy list URL. So the app queried wrong data.

Fix: Use conf.RMMAPI + 'records/fields'.