### PR TITLE
Added Google Analytics 4

### DIFF
--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -55,6 +55,7 @@ export class AppComponent implements AfterViewInit {
 
   menuHoverActive: boolean;
   gaCode: string = null;
+  ga4Code: string = null;
 
   @ViewChild('layoutContainer') layourContainerViewChild: ElementRef;
 
@@ -76,6 +77,7 @@ export class AppComponent implements AfterViewInit {
       this.appConfig.getConfig().subscribe(
           (conf) => {
               this.gaCode = conf.GACODE;
+              this.ga4Code = conf.GA4CODE;
 
               /**
                * Added Google Analytics service to html
@@ -87,7 +89,7 @@ export class AppComponent implements AfterViewInit {
                * menu and footer links.  But we still need to track user event of the 
                * dynamic content.
                */
-              this.gaService.appendGaTrackingCode(this.gaCode);
+              this.gaService.appendGaTrackingCode(this.gaCode, this.ga4Code);
           }
       );
   }

--- a/angular/src/app/shared/ga-service/google-analytics.service.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.ts
@@ -66,25 +66,59 @@ export class GoogleAnalyticsService {
 *   First we read the tracking code from the config server, then form the script src and added the script
 *   to the top of current page. 
 */
-  public appendGaTrackingCode(gaCode: string) {
+  public appendGaTrackingCode(gaCode: string, ga4Code: string) {
     try {
-      let scriptId = '_fed_an_ua_tag';
+        //GA3
+        let scriptId = '_fed_an_ua_tag';
 
-      if (document.getElementById(scriptId)) {
-        console.log("Found GA id.");
-        document.getElementById(scriptId).remove();
-      }
+        if (document.getElementById(scriptId)) {
+            console.log("Found GA id.");
+            document.getElementById(scriptId).remove();
+        }
 
-      var s = document.createElement('script') as any;
-      s.type = "text/javascript";
-      s.id = scriptId;
-      s.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=" + gaCode + "&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c";
+        var s = document.createElement('script') as any;
+        s.type = "text/javascript";
+        s.id = scriptId;
+        s.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=" + gaCode + "&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c";
 
-      var h = document.getElementsByTagName("head");
-      document.getElementsByTagName("head")[0].appendChild(s);
+        var h = document.getElementsByTagName("head");
+        document.getElementsByTagName("head")[0].appendChild(s);
+
+        //GA4
+        scriptId = '_gtag_js';
+
+        if (document.getElementById(scriptId)) {
+            console.log("Found GA id.");
+            document.getElementById(scriptId).remove();
+        }
+
+        var s1 = document.createElement('script') as any;
+        s1.type = "text/javascript";
+        s1.id = scriptId;
+        s1.async = true;
+        s1.src = "https://www.googletagmanager.com/gtag/js?id=" + ga4Code;
+
+        var h1 = document.getElementsByTagName("head");
+        document.getElementsByTagName("head")[0].appendChild(s1);
+
+        scriptId = '_dataLayer';
+
+        if (document.getElementById(scriptId)) {
+            console.log("Found GA id.");
+            document.getElementById(scriptId).remove();
+        }
+
+        var s2 = document.createElement('script') as any;
+        s2.type = "text/javascript";
+        s2.id = scriptId;
+        s2.text = "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '" + ga4Code+ "');";
+
+        var h2 = document.getElementsByTagName("head");
+        document.getElementsByTagName("head")[0].appendChild(s2);
+        
     } catch (ex) {
-      console.error('Error appending google analytics');
-      console.error(ex);
+        console.error('Error appending google analytics');
+        console.error(ex);
     }
   }
 }

--- a/angular/src/assets/environment.json
+++ b/angular/src/assets/environment.json
@@ -7,5 +7,6 @@
     "METAPI":  "http://localhost/metaurl/",
     "LANDING": "http://data.nist.gov/rmm/",
     "GACODE": "not-set",
+    "GA4CODE": "G-B91GVV0J5B",
     "APPVERSION": "1.3.0"
 }


### PR DESCRIPTION
This branch added Google Analytics code to SDP.

To test it locally, 

1. Login your gmail account
2. Go to https://analytics.google.com/, click on the "admin" icon at bottom left of the screen 
3. Create a new account. 
4. Add a new Data Streams and set the stream url to http://127.0.0.1:5555/#/ and provide a stream name. 
5. Note MEASUREMENT ID generated by Google Analytics. 
6. Replace src/assets/environment.ts and replace the value of "GA4CODE" with the MEASUREMENT ID got from step 5.
7. Compile and run SDP by using "npm i" and "npm start" command.
8. Open localhost:5555 
9. Open https://analytics.google.com/, select the GA account you just generated
10. Replace the GA4 value in src\assets\environment.json with this MEASUREMENT ID.
11. Open Google Analytics realtime report, you should see some activites while you interact with the UI such as scroll, click...

We still keep the code for GA3.

