### PR TITLE
Handle page view for SPA

### DIFF
--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -61,6 +61,7 @@ export class AppComponent implements AfterViewInit {
   menuHoverActive: boolean;
   gaCode: string = null;
   ga4Code: string = null;
+  hostName: string = "dada.nist.gov";
 
   @ViewChild('layoutContainer') layourContainerViewChild: ElementRef;
 
@@ -86,6 +87,8 @@ export class AppComponent implements AfterViewInit {
             (conf) => {
                 this.gaCode = conf.GACODE;
                 this.ga4Code = conf.GA4CODE;
+                const url = new URL(conf.SERVERBASE);
+                this.hostName = url.hostname;
 
                 /**
                  * Added Google Analytics service to html
@@ -97,7 +100,7 @@ export class AppComponent implements AfterViewInit {
                  * menu and footer links.  But we still need to track user event of the 
                  * dynamic content.
                  */
-                this.gaService.appendGaTrackingCode(this.gaCode, this.ga4Code);
+                this.gaService.appendGaTrackingCode(this.gaCode, this.ga4Code, this.hostName);
 
                 //Add GA4 code to track page view
                 this.handleRouteEvents();
@@ -111,14 +114,15 @@ export class AppComponent implements AfterViewInit {
     handleRouteEvents() {
         this.router.events.subscribe(event => {
             if (event instanceof NavigationEnd) {
-                console.log('event', event);
                 const title = this.getTitle(this.router.routerState, this.router.routerState.root).join('-');
-                console.log('title', title);
                 this.titleService.setTitle(title);
+                
                 gtag('event', 'page_view', {
                     page_title: title,
                     page_path: event.urlAfterRedirects,
-                    page_location: this.document.location.href
+                    page_location: this.document.location.href,
+                    cookie_domain: this.hostName, 
+                    cookie_flags: 'SameSite=None;Secure'
                 })
             }
         });

--- a/angular/src/app/shared/ga-service/google-analytics.service.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.ts
@@ -32,10 +32,6 @@ export class GoogleAnalyticsService {
 
   // Tracking events
   gaTrackEvent(category: string, event?: any, label?: string, action?: string) {
-    console.log('Tracking: category', category);
-    console.log('Tracking: event', event);
-    console.log('Tracking: label', label);
-    console.log('Tracking: action', action);
     if (action == undefined) {
       // menu item
       if (event.item != undefined) {
@@ -57,7 +53,6 @@ export class GoogleAnalyticsService {
     action = (action == undefined) ? "" : action;
     label = (label == undefined) ? "" : label;
 
-    console.log("Calling gas(): Event category", category, "action", action, "label", label);
     gas('send', 'event', category, action, label, 1);
   }
 
@@ -66,13 +61,12 @@ export class GoogleAnalyticsService {
 *   First we read the tracking code from the config server, then form the script src and added the script
 *   to the top of current page. 
 */
-  public appendGaTrackingCode(gaCode: string, ga4Code: string) {
+  public appendGaTrackingCode(gaCode: string, ga4Code: string, hostname: string = "dada.nist.gov") {
     try {
         //GA3
         let scriptId = '_fed_an_ua_tag';
 
         if (document.getElementById(scriptId)) {
-            console.log("Found GA id.");
             document.getElementById(scriptId).remove();
         }
 
@@ -88,7 +82,6 @@ export class GoogleAnalyticsService {
         scriptId = '_gtag_js';
 
         if (document.getElementById(scriptId)) {
-            console.log("Found GA id.");
             document.getElementById(scriptId).remove();
         }
 
@@ -104,14 +97,13 @@ export class GoogleAnalyticsService {
         scriptId = '_dataLayer';
 
         if (document.getElementById(scriptId)) {
-            console.log("Found GA id.");
             document.getElementById(scriptId).remove();
         }
 
         var s2 = document.createElement('script') as any;
         s2.type = "text/javascript";
         s2.id = scriptId;
-        s2.text = "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '" + ga4Code+ "');";
+        s2.text = "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '" + ga4Code+ "',{'cookie_domain':'"+ hostname + "','cookie_flags': 'SameSite=None;Secure'})";
 
         var h2 = document.getElementsByTagName("head");
         document.getElementsByTagName("head")[0].appendChild(s2);


### PR DESCRIPTION
Google Analytics is not notified when we route to a page inside SPA. To fix that, we subscribe to the Angular router inside the app.component.ts file and send the new routes to Google Analytics.

Now the page view will be triggered when user clicks on the search button or open Advanced Search page. 