### PR TITLE
Support Mac ARM processors: drop dependency on PhantomJS

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -64,7 +64,6 @@
     "karma-coverage-istanbul-reporter": "~3.0.2",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.6.0",
-    "karma-phantomjs-launcher": "^1.0.4",
     "protractor": "~7.0.0",
     "ts-node": "~7.0.0",
     "tslint": "^5.20.1",


### PR DESCRIPTION
Builds on Mac that feature the m1 ARM processor fail because there is not a compatible version of the PhantomJS package.  PhantomJS is a no-longer supported package intended enable unit-testing of Javacript code that is targeted for a browser environment.   Since this capability is covered by our use of "headless" Chrome, the PhantomJS package is not needed.  This PR removes PhantomJS as a build dependency.  