### PR TITLE
Fixed multiple loads of fields

### DIFF
--- a/angular/src/app/adv-search/adv-search.component.ts
+++ b/angular/src/app/adv-search/adv-search.component.ts
@@ -92,6 +92,12 @@ export class AdvSearchComponent extends FormCanDeactivate implements OnInit, Aft
         this.mobWidth = (window.innerWidth);
         // Init search box size and breadcrumb position
         this.onWindowResize();
+
+        this.searchFieldsListService.watchFields(
+            (fields) =>{
+                this.fields = (fields as SelectItem[]);
+            }
+        );
     }
 
     /**
@@ -99,26 +105,7 @@ export class AdvSearchComponent extends FormCanDeactivate implements OnInit, Aft
      */
     ngOnInit() {
         var i = 0;
-
-        this.searchFieldsListService.getSearchFields().subscribe(
-            (fields) => {
-                this.fields = (fields as SelectItem[]);
-                this.queries = this.searchQueryService.getQueries();
-                this.currentQueryInfo = this.searchQueryService.getCurrentQueryInfo();
-                this.currentQuery = this.currentQueryInfo.query;
-                this.dataChanged = this.currentQueryInfo.dataChanged;   //Restore status
-                this.currentQueryIndex = this.currentQueryInfo.queryIndex;
-                if(!this.currentQuery) this.currentQuery = new SDPQuery();
-                if(this.currentQuery.queryRows.length == 0) this.currentQuery.queryRows.push(new QueryRow());
-
-                this.searchValue = this.searchQueryService.buildSearchString(this.currentQuery);
-                // Update search box in the top search panel
-                this.searchService.setQueryValue(this.searchValue, '', '');
-            },
-            (err) => {
-                this.errorMessage = <any>err;
-            }
-        );
+        this.setSearchQuery();
 
         this.searchQueryService.watchQueries().subscribe(value => {
             if(value)
@@ -126,6 +113,19 @@ export class AdvSearchComponent extends FormCanDeactivate implements OnInit, Aft
         });
     }
 
+    setSearchQuery() {
+        this.queries = this.searchQueryService.getQueries();
+        this.currentQueryInfo = this.searchQueryService.getCurrentQueryInfo();
+        this.currentQuery = this.currentQueryInfo.query;
+        this.dataChanged = this.currentQueryInfo.dataChanged;   //Restore status
+        this.currentQueryIndex = this.currentQueryInfo.queryIndex;
+        if(!this.currentQuery) this.currentQuery = new SDPQuery();
+        if(this.currentQuery.queryRows.length == 0) this.currentQuery.queryRows.push(new QueryRow());
+
+        this.searchValue = this.searchQueryService.buildSearchString(this.currentQuery);
+        // Update search box in the top search panel
+        this.searchService.setQueryValue(this.searchValue, '', '');
+    }
     /**
      *  Following functions detect screen size
      */

--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { concat } from 'rxjs';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router, RouterState } from '@angular/router';
 import { DOCUMENT } from '@angular/common';
+import { TaxonomyListService, SearchfieldsListService } from './shared/index';
 
 enum MenuOrientation {
   STATIC,
@@ -74,6 +75,7 @@ export class AppComponent implements AfterViewInit {
     private gaService: GoogleAnalyticsService,
     public router: Router,
     private titleService: Title,
+    public searchFieldsListService: SearchfieldsListService,
     @Inject(DOCUMENT) private document: Document) {
         
   }
@@ -106,6 +108,8 @@ export class AppComponent implements AfterViewInit {
                 this.handleRouteEvents();
             }
         );
+
+        this.searchFieldsListService.getSearchFields();
     }
 
     /**

--- a/angular/src/app/home/home.component.html
+++ b/angular/src/app/home/home.component.html
@@ -1,13 +1,5 @@
 <app-search-panel title='NIST Data Discovery' [subtitle]='true' [helpicon]='false' [advanceLink]='true' [homePage]='true' jumbotronHeight='35vh' jumbotronPadding='2em 3em 0em 3em'></app-search-panel>
 
-<!-- <div class="p-col" style="background-color: #F5F5F5;padding-top: 10px;">
-  <div id="feature" class="p-col-12 p-md-8 p-lg-8 featured-data"> <b>SCIENCE THEME</b>
-    <div class="feature-data-domain-divider">
-      <hr class="feature-divider">
-    </div>
-  </div>
-</div> -->
-
 <!-- First row -->
 <div style="background-color: #F5F5F5;padding-top: 2em;">
     <div class="grid" style="width: 90%; margin: auto;">

--- a/angular/src/app/search-panel/search-panel.component.ts
+++ b/angular/src/app/search-panel/search-panel.component.ts
@@ -130,6 +130,12 @@ export class SearchPanelComponent implements OnInit {
 
         this.mobHeight = (window.innerHeight);
         this.mobWidth = (window.innerWidth);
+
+        this.searchFieldsListService.watchFields(
+            (fields) => {
+                this.fields = fields;
+            }
+        )
     }
 
     /**
@@ -144,7 +150,7 @@ export class SearchPanelComponent implements OnInit {
             });
         };
 
-        this.observableFields = this.searchFieldsListService.getSearchFields();
+        // this.observableFields = this.searchFieldsListService.getSearchFields();
 
         this.searchService._watchQueryValue((queryObj) => {
             if (queryObj && queryObj.queryString && queryObj.queryString.trim() != '') {
@@ -157,15 +163,6 @@ export class SearchPanelComponent implements OnInit {
         this.searchQueryService._watchShowExamples((showExample) => {
                 this.showExampleStatus = showExample;
                 this.changeState(showExample); 
-            }
-        );
-
-        this.searchFieldsListService.getSearchFields().subscribe(
-            (fields) => {
-                this.fields = (fields as SelectItem[]);
-            },
-            (err) => {
-                console.log("Error getting fields.", err);
             }
         );
 

--- a/angular/src/app/search/filters/filters.component.ts
+++ b/angular/src/app/search/filters/filters.component.ts
@@ -14,7 +14,6 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
     selector: 'app-filters',
     templateUrl: './filters.component.html',
     styleUrls: ['./filters.component.css'],
-    providers: [TaxonomyListService, SearchfieldsListService],
     animations: [
         trigger('expand', [
             state('closed', style({height: '40px'})),
@@ -135,7 +134,14 @@ export class FiltersComponent implements OnInit, AfterViewInit {
         public taxonomyListService: TaxonomyListService,
         public searchFieldsListService: SearchfieldsListService
     ){ 
-
+        this.searchFieldsListService.watchFields(
+            (fields) => {
+                if(fields.length > 0){
+                    this.toSortItems(fields);
+                    this.queryAndSearch();
+                }
+            }
+        )
     }
 
     /**
@@ -158,7 +164,7 @@ export class FiltersComponent implements OnInit, AfterViewInit {
 
                 //Clear filters when we conduct a new search
                 this.clearFilters();
-                this.getFields();
+                this.queryAndSearch();
             }
         }
 
@@ -192,25 +198,19 @@ export class FiltersComponent implements OnInit, AfterViewInit {
     /**
      * Get the filterable fields and then do the search
      */
-    getFields() {
-        this.searchFieldsListService.get().subscribe(
-            fields => {
-                this.toSortItems(fields);
-                this.searchService.setQueryValue(this.searchValue, '', '');
-                this.queryStringErrorMessage = this.searchQueryService.validateQueryString(this.searchValue);
-                if(! this.queryStringErrorMessage){ 
-                    this.queryStringError = true;
-                }
-
-                let lSearchValue = this.searchValue.replace(/  +/g, ' ');
-
-                //Convert to a query then search
-                this.doSearch(this.searchQueryService.buildQueryFromString(lSearchValue, null, this.fields));
-            },
-            error => {
-                this.errorMessage = <any>error
+    queryAndSearch() {
+        if(this.fields) {
+            this.searchService.setQueryValue(this.searchValue, '', '');
+            this.queryStringErrorMessage = this.searchQueryService.validateQueryString(this.searchValue);
+            if(! this.queryStringErrorMessage){ 
+                this.queryStringError = true;
             }
-        );
+
+            let lSearchValue = this.searchValue? this.searchValue.replace(/  +/g, ' ') : "";
+
+            //Convert to a query then search
+            this.doSearch(this.searchQueryService.buildQueryFromString(lSearchValue, null, this.fields));
+        }
     }
 
     /**

--- a/angular/src/app/search/results/results.component.ts
+++ b/angular/src/app/search/results/results.component.ts
@@ -68,6 +68,15 @@ export class ResultsComponent implements OnInit {
         this.appConfig.getConfig().subscribe(
             (conf) => { this.PDRAPIURL = conf.PDRAPI; },
         );
+
+        this.searchFieldsListService.watchFields(
+            (fields) => {
+                this.filterableFields = this.toSortItems(fields);
+
+                //Convert to a query then search
+                this.searchSubscription = this.search(null, 1, this.itemsPerPage);
+            }
+        )
     }
     
     ngOnInit() {
@@ -78,18 +87,6 @@ export class ResultsComponent implements OnInit {
             if(this.queryStringErrorMessage != "")
                 this.queryStringWarning = true;
         }
-
-        this.searchFieldsListService.get().subscribe(
-            fields => {
-                this.filterableFields = this.toSortItems(fields);
-
-                //Convert to a query then search
-                this.searchSubscription = this.search(null, 1, this.itemsPerPage);
-            },
-            error => {
-                this.errorMessage = <any>error
-            }
-        );
 
         this.pageSubscription = (this.searchService.watchCurrentPage().subscribe(page => {
             if(!page) page=1;

--- a/angular/src/app/shared/search-query/search-query.service.ts
+++ b/angular/src/app/shared/search-query/search-query.service.ts
@@ -548,6 +548,8 @@ export class SearchQueryService {
      * @param queryString input query string
      */
     validateQueryString(queryString: string){
+        if(!queryString) return "";
+
         let queryStringErrorMessage = "";
         let lQueryString: string = "";
         let errorCount: number = 0;


### PR DESCRIPTION
Issue: SDP queries fields 5 times at start up.
https://sgitlab.nist.gov/oar-odd/science-data-portal/-/issues/12

Root cause: the search panel at top of home, search result and Advanced Search queries fields on init.

Solution: make fields observable in search filed service and only query fields once at start up.

Test: run SDP locally and browse http://localhost:5555. Open developer console and go to network tab. Make sure {fields} only show up once.
