### PR TITLE
Fixed search issue - always return all records

### DIFF
--- a/angular/src/app/adv-search/adv-search.component.ts
+++ b/angular/src/app/adv-search/adv-search.component.ts
@@ -95,7 +95,7 @@ export class AdvSearchComponent extends FormCanDeactivate implements OnInit, Aft
 
         this.searchFieldsListService.watchFields(
             (fields) =>{
-                this.fields = (fields as SelectItem[]);
+                this.fields = this.toFieldItems(fields);
             }
         );
     }
@@ -579,4 +579,32 @@ export class AdvSearchComponent extends FormCanDeactivate implements OnInit, Aft
         this.searchQueryService.saveQueries(this.queries);
         op.hide();
     }
+
+    /**
+     * Advanced Search fields dropdown
+     */
+    toFieldItems(fields: any[]): SelectItem[] {
+        // let items: SelectItem[] = [];
+        // items.push({ label: this.ALL, value: 'searchphrase' });
+        let fieldItems: SelectItem[] = [];
+        for (let field of fields) {
+            if (_.includes(field.tags, 'searchable')) {
+                let dup = false;
+                //For some reason, the filter function does not work for fields. Have to use this loop...
+                for(let item of fieldItems){
+                    if(item.label == field.label && item.value == field.name.replace('component.', 'components.')){
+                        dup = true;
+                        break;
+                    }
+                }
+
+                if(!dup){
+                    fieldItems.push({ label: field.label, value: field.name.replace('component.', 'components.') });
+                }
+            }
+        };
+        fieldItems = _.sortBy(fieldItems, ['label', 'value']);
+
+        return fieldItems;
+    }    
 }

--- a/angular/src/app/search-panel/search-panel.component.html
+++ b/angular/src/app/search-panel/search-panel.component.html
@@ -18,7 +18,7 @@
                     <div class="inner-addon left-addon background-white search-box" >
                         <i class="glyphicon faa faa-search" style="cursor: pointer;z-index: 999 !important;float: left;" (click)="hideAllHelp();search(searchValue,searchTaxonomyKey)"></i>
                         <div>
-                            <p-autoComplete p-fluid #audocomp [inputStyle]="inputStyle" (onFocus)="clearText()"
+                            <p-autoComplete p-fluid #audocomp [inputStyle]="inputStyle" (onFocus)="selectAll()"
                                 (onBlur)="addPlaceholder()" [placeholder]="placeholder" [(ngModel)]="searchValue"
                                 inputId="searchinput" name="searchinput"
                                  (keyup.enter)="audocomp.handleDropdownClick();search(searchValue,searchTaxonomyKey)"

--- a/angular/src/app/search-panel/search-panel.component.ts
+++ b/angular/src/app/search-panel/search-panel.component.ts
@@ -250,12 +250,10 @@ export class SearchPanelComponent implements OnInit {
     /**
      *  Clear the search text box
      */
-    clearText() {
+    selectAll() {
         var field = (<HTMLInputElement>document.getElementById('searchinput'));
 
-        if (!Boolean(this._searchValue.trim())) {
-            field.value = ' ';
-        }
+        field.select();
     }
 
     /**

--- a/angular/src/app/search/filters/filters.component.ts
+++ b/angular/src/app/search/filters/filters.component.ts
@@ -138,7 +138,6 @@ export class FiltersComponent implements OnInit, AfterViewInit {
             (fields) => {
                 if(fields.length > 0){
                     this.toSortItems(fields);
-                    this.queryAndSearch();
                 }
             }
         )

--- a/angular/src/app/search/results/results.component.ts
+++ b/angular/src/app/search/results/results.component.ts
@@ -71,10 +71,9 @@ export class ResultsComponent implements OnInit {
 
         this.searchFieldsListService.watchFields(
             (fields) => {
-                this.filterableFields = this.toSortItems(fields);
-
-                //Convert to a query then search
-                this.searchSubscription = this.search(null, 1, this.itemsPerPage);
+                if(fields && fields.length > 0) {
+                    this.filterableFields = this.toSortItems(fields);
+                }
             }
         )
     }
@@ -106,7 +105,13 @@ export class ResultsComponent implements OnInit {
             this.searchSubscription = this.search(null, null, this.itemsPerPage);
         }));
 
+        this.searchSubscription = this.search(null, 1, this.itemsPerPage);
+
         this.inited = true;
+    }
+
+    ngAfterViewInit(): void {
+        // this.searchSubscription = this.search(null, 1, this.itemsPerPage);
     }
 
     /**

--- a/angular/src/app/shared/config-service/config.service.spec.ts
+++ b/angular/src/app/shared/config-service/config.service.spec.ts
@@ -41,8 +41,8 @@ describe('AppConfig', () => {
 
         service.getRemoteConfig().subscribe(
             (conf) => {
-                expect(conf["SERVERBASE"]).toEqual("http://data.nist.gov");
-                expect(conf["RMMAPI"]).toEqual("http://data.nist.gov/rmm/");
+                expect(conf["SERVERBASE"]).toEqual("https://data.nist.gov");
+                expect(conf["RMMAPI"]).toEqual("https://data.nist.gov/rmm/");
                 expect(conf["SDPAPI"]).toEqual("http://localhost:5555/");
                 expect(conf.GACODE).toEqual("not-set");
                 expect(conf.APPVERSION).toEqual("1.3.0");
@@ -59,8 +59,8 @@ describe('AppConfig', () => {
         service.loadRemoteConfig();
         service.getConfig().subscribe(
             (conf) => {
-                expect(conf["SERVERBASE"]).toEqual("http://data.nist.gov");
-                expect(conf["RMMAPI"]).toEqual("http://data.nist.gov/rmm/");
+                expect(conf["SERVERBASE"]).toEqual("https://data.nist.gov");
+                expect(conf["RMMAPI"]).toEqual("https://data.nist.gov/rmm/");
                 expect(conf["SDPAPI"]).toEqual("http://localhost:5555/");
                 expect(conf.GACODE).toEqual("not-set");
                 expect(conf.APPVERSION).toEqual("1.3.0");

--- a/angular/src/app/shared/search-service/search-service.service.real.ts
+++ b/angular/src/app/shared/search-service/search-service.service.real.ts
@@ -131,7 +131,8 @@ export class RealSearchService implements SearchService{
             url = 'records?';
     
             if(searchPhraseValue)
-                url += "&" + searchPhraseValue.trim();
+                url += searchPhraseValue.trim();
+            // url += "&" + searchPhraseValue.trim();
            
             if(sortOrder){
                 url += '&sort.asc=' + sortOrder;
@@ -160,6 +161,7 @@ export class RealSearchService implements SearchService{
             url += '&include=ediid,description,title,keyword,topic.tag,contactPoint,components,@type,doi,landingPage&exclude=_id';
         }
 
+        console.log("Calling back end==============:", url);
         return this.appConfig.getConfig().pipe(
             rxjsop.mergeMap((conf) => {
                 return this.http.get(conf.RMMAPI + url);

--- a/angular/src/app/shared/searchfields-list/searchfields-list.service.ts
+++ b/angular/src/app/shared/searchfields-list/searchfields-list.service.ts
@@ -69,7 +69,7 @@ export class SearchfieldsListService {
             next: (conf) => {
                 this.get(conf.RMMAPI + 'records/fields').subscribe({
                     next: (res) => {
-                        this.setFields(this.toFieldItems(res));
+                        this.setFields(res);
                     },
                     error: (err) => {
                         console.error(err);
@@ -82,33 +82,5 @@ export class SearchfieldsListService {
                 //display error message on screen...
             }
         })
-    }
-
-    /**
-     * Advanced Search fields dropdown
-     */
-    toFieldItems(fields: any[]): SelectItem[] {
-        // let items: SelectItem[] = [];
-        // items.push({ label: this.ALL, value: 'searchphrase' });
-        let fieldItems: SelectItem[] = [];
-        for (let field of fields) {
-            if (_.includes(field.tags, 'searchable')) {
-                let dup = false;
-                //For some reason, the filter function does not work for fields. Have to use this loop...
-                for(let item of fieldItems){
-                    if(item.label == field.label && item.value == field.name.replace('component.', 'components.')){
-                        dup = true;
-                        break;
-                    }
-                }
-
-                if(!dup){
-                    fieldItems.push({ label: field.label, value: field.name.replace('component.', 'components.') });
-                }
-            }
-        };
-        fieldItems = _.sortBy(fieldItems, ['label', 'value']);
-
-        return fieldItems;
     }
 }

--- a/angular/src/assets/environment.json
+++ b/angular/src/assets/environment.json
@@ -1,6 +1,6 @@
 {
-    "SERVERBASE": "http://data.nist.gov/",
-    "RMMAPI":  "http://data.nist.gov/rmm/",
+    "SERVERBASE": "https://data.nist.gov/",
+    "RMMAPI":  "https://data.nist.gov/rmm/",
     "SDPAPI":  "http://localhost:5555/",
     "PDRAPI":  "http://localhost:4200/od/id/",
     "DISTAPI": "http://data.nist.gov/od/ds/",


### PR DESCRIPTION
Original ticket: https://sgitlab.nist.gov/oar-odd/science-data-portal/-/issues/13
 
Fixes:
1. When the search box on focus, select all. This will avoid the leading space.
2. Disabled one search function in field watch function in filters component which is not necessary.
3. Moved one search function from field watch function to ngOnInit in results component.
4. Moved toFieldItems() function from searchfields-list service to advanced search component. This fixed a new problem I discovered: Customize View dropdown missing fields.
5. Fixed unit test.
 
Should only see three queries when user do a search: one for field list, one for filters and one for result page.
 
To test it locally, run npm start.