### PR TITLE
Fix: headbar dropdown hide on mouseleave

### DIFF
--- a/angular/src/app/frame/headbar/headbar.component.css
+++ b/angular/src/app/frame/headbar/headbar.component.css
@@ -77,3 +77,4 @@
 ::ng-deep .p-menubar .p-menubar-end {
   margin-left: auto;
 }
+

--- a/angular/src/app/frame/headbar/headbar.component.html
+++ b/angular/src/app/frame/headbar/headbar.component.html
@@ -1,4 +1,4 @@
-<p-menubar [model]="items">
+<p-menubar #menubar [model]="items">
   <ng-template pTemplate="start">
     <div
       id="logo"

--- a/angular/src/app/frame/headbar/headbar.component.spec.ts
+++ b/angular/src/app/frame/headbar/headbar.component.spec.ts
@@ -16,9 +16,13 @@ import {
   withInterceptorsFromDi,
 } from "@angular/common/http";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { MenubarModule } from "primeng/menubar";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+
 describe("HeadbarComponent", () => {
   let component: HeadbarComponent;
   let fixture: ComponentFixture<HeadbarComponent>;
+  let renderer: Renderer2;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -34,6 +38,8 @@ describe("HeadbarComponent", () => {
         RouterTestingModule,
         MockModule,
         ToastrModule.forRoot(),
+        MenubarModule,
+        NoopAnimationsModule,
       ],
       providers: [
         AppComponent,
@@ -51,10 +57,55 @@ describe("HeadbarComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HeadbarComponent);
     component = fixture.componentInstance;
+    renderer = fixture.componentRef.injector.get(Renderer2);
     fixture.detectChanges();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should hide dropdown when mouse leaves", async () => {
+    // Wait for initial render
+    await fixture.whenStable();
+
+    // Ensure menubar is initialized
+    expect(component.menubar).toBeTruthy();
+
+    const menubarElement = fixture.nativeElement.querySelector("p-menubar");
+
+    // First show the dropdown
+    component.menubar.show();
+    fixture.detectChanges();
+
+    // Then hide it
+    component.menubar.hide();
+    fixture.detectChanges();
+
+    // Check for active menu items (should be none after hide)
+    const activeMenuItems =
+      menubarElement.querySelectorAll(".p-menuitem-active");
+    expect(activeMenuItems.length).toBe(0);
+
+    // Check that overlay is hidden
+    const visibleOverlay = menubarElement.querySelector(
+      '.p-menubar-root-list[role="menubar"]'
+    );
+    expect(
+      visibleOverlay?.classList.contains("p-submenu-list-active")
+    ).toBeFalsy();
+  });
+
+  it("should show dropdown when mouse enters", () => {
+    const menubarElement = fixture.nativeElement.querySelector("p-menubar");
+    const mouseEnterEvent = new Event("mouseenter");
+    menubarElement.dispatchEvent(mouseEnterEvent);
+    fixture.detectChanges();
+
+    const dropdownItems = menubarElement.querySelectorAll(".p-submenu-list");
+    dropdownItems.forEach((item) => {
+      const style = getComputedStyle(item);
+      expect(style.display).toBe("block");
+    });
   });
 });

--- a/angular/src/app/frame/headbar/headbar.component.ts
+++ b/angular/src/app/frame/headbar/headbar.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnInit, Inject, forwardRef } from "@angular/core";
+import {
+  Component,
+  OnInit,
+  Inject,
+  ViewChild,
+  ElementRef,
+  AfterViewInit,
+  Renderer2,
+} from "@angular/core";
 import { AppComponent } from "../../app.component";
 import { SearchQueryService } from "../../shared/search-query/search-query.service";
 import * as _ from "lodash-es";
@@ -7,6 +15,7 @@ import { SDPQuery } from "../../shared/search-query/query";
 import { SearchService, SEARCH_SERVICE } from "../../shared/search-service";
 import { Router } from "@angular/router";
 import { MenuItem } from "primeng/api";
+import { Menubar } from "primeng/menubar";
 
 @Component({
   selector: "app-headbar",
@@ -14,6 +23,7 @@ import { MenuItem } from "primeng/api";
   styleUrls: ["./headbar.component.css"],
 })
 export class HeadbarComponent implements OnInit {
+  @ViewChild("menubar") menubar: Menubar;
   queryLength: number;
   appVersion: string;
   queries: SDPQuery[] = [];
@@ -24,7 +34,8 @@ export class HeadbarComponent implements OnInit {
     public app: AppComponent,
     public searchQueryService: SearchQueryService,
     private appConfig: AppConfig,
-    public router: Router
+    public router: Router,
+    private renderer: Renderer2
   ) {
     this.searchQueryService.watchQueries().subscribe((value) => {
       this.queries = value as SDPQuery[];
@@ -36,7 +47,7 @@ export class HeadbarComponent implements OnInit {
     this.queryLength = this.searchQueryService.getQueries().length;
     this.queries = this.searchQueryService.getQueries();
     this.appConfig.getConfig().subscribe((conf) => {
-      this.appVersion = conf.APPVERSION
+      this.appVersion = conf.APPVERSION;
     });
 
     this.items = [
@@ -166,6 +177,12 @@ export class HeadbarComponent implements OnInit {
         ],
       },
     ];
+  }
+
+  ngAfterViewInit() {
+    this.renderer.listen(this.menubar.el.nativeElement, "mouseleave", () => {
+      this.menubar.hide();
+    });
   }
 
   hideExamples() {


### PR DESCRIPTION
This PR fixes the headbar component's behavior when it comes to the dropdown items.

The dropdowns now hide instantly once the mouse leaves the area.