### PR TITLE
fix: removing dataset from filters for clarity

### DIFF
--- a/angular/src/app/search/filters/filters.component.spec.ts
+++ b/angular/src/app/search/filters/filters.component.spec.ts
@@ -1,75 +1,86 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FiltersComponent } from './filters.component';
-import { TreeModule } from 'primeng/tree';
-import { AutoCompleteModule } from 'primeng/autocomplete';
-import { MockModule } from '../../mock.module';
-import { FormsModule } from '@angular/forms';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { ToastrModule } from 'ngx-toastr';
-import { BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import { FiltersComponent } from "./filters.component";
+import { TreeModule } from "primeng/tree";
+import { AutoCompleteModule } from "primeng/autocomplete";
+import { MockModule } from "../../mock.module";
+import { FormsModule } from "@angular/forms";
+import { provideHttpClientTesting } from "@angular/common/http/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { ToastrModule } from "ngx-toastr";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
 
-describe('FiltersComponent', () => {
-    let component: FiltersComponent;
-    let fixture: ComponentFixture<FiltersComponent>;
-    let searchResult = require('../../../assets/sample02.json').ResultData;
+describe("FiltersComponent", () => {
+  let component: FiltersComponent;
+  let fixture: ComponentFixture<FiltersComponent>;
+  let searchResult = require("../../../assets/sample02.json").ResultData;
 
-    beforeEach(waitForAsync(() => {
-        TestBed.configureTestingModule({
-    declarations: [FiltersComponent],
-    imports: [TreeModule,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [FiltersComponent],
+      imports: [
+        TreeModule,
         AutoCompleteModule,
         MockModule,
         FormsModule,
         BrowserAnimationsModule,
         RouterTestingModule,
-        ToastrModule.forRoot()],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-})
-        .compileComponents();
-    }));
+        ToastrModule.forRoot(),
+      ],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+  }));
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(FiltersComponent);
-        component = fixture.componentInstance;
-        component.fields = [];
-        component.searchValue = "";
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FiltersComponent);
+    component = fixture.componentInstance;
+    component.fields = [];
+    component.searchValue = "";
+    fixture.detectChanges();
+  });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
 
-    it('onSuccess', () => {
-        component.onSuccess(searchResult);
-        expect(component.keywords.length).toEqual(38);
-        expect(component.keywords[0]).toEqual("Advanced Functional Materials");
+  it("onSuccess", () => {
+    component.onSuccess(searchResult);
+    expect(component.keywords.length).toEqual(38);
+    expect(component.keywords[0]).toEqual("Advanced Functional Materials");
 
-        expect(component.themes.length).toEqual(8);
-        expect(component.themes[0].label).toEqual("Nanotechnology");
+    expect(component.themes.length).toEqual(8);
+    expect(component.themes[0].label).toEqual("Nanotechnology");
 
-        expect(component.resourceTypes.length).toEqual(2);
-        expect(component.resourceTypes[0].label).toEqual("Public Data Resource");
+    // Updated expectation: now expecting only 1 resource type since "Dataset" is filtered out
+    expect(component.resourceTypes.length).toEqual(1);
+    expect(component.resourceTypes[0].label).toEqual("Public Data Resource");
 
-        expect(component.components.length).toEqual(4);
-        expect(component.components[0].label).toEqual("Data File");
+    expect(component.components.length).toEqual(4);
+    expect(component.components[0].label).toEqual("Data File");
 
-        expect(component.componentsWithCount.length).toEqual(2);
-        expect(component.componentsWithCount[0].label).toEqual("Data File-4");
-        expect(component.componentsWithCount[1].label).toEqual("Access Page-1");
+    expect(component.componentsWithCount.length).toEqual(2);
+    expect(component.componentsWithCount[0].label).toEqual("Data File-4");
+    expect(component.componentsWithCount[1].label).toEqual("Access Page-1");
 
-        expect(component.themesWithCount.length).toEqual(8);
-        expect(component.themesWithCount[0].label).toEqual("Nanotechnology-6");
-        expect(component.themesWithCount[7].label).toEqual("Electronics-1");
+    expect(component.themesWithCount.length).toEqual(8);
+    expect(component.themesWithCount[0].label).toEqual("Nanotechnology-6");
+    expect(component.themesWithCount[7].label).toEqual("Electronics-1");
 
-        expect(component.resourceTypesWithCount.length).toEqual(2);
-        expect(component.resourceTypesWithCount[0].label).toEqual("Public Data Resource-6");
-        expect(component.resourceTypesWithCount[1].label).toEqual("Dataset-3");
+    // Updated expectation: now expecting only 1 resource type with count
+    expect(component.resourceTypesWithCount.length).toEqual(1);
+    expect(component.resourceTypesWithCount[0].label).toEqual(
+      "Public Data Resource-6"
+    );
+    // Removed the "Dataset-3" expectation since it's now filtered out
 
-        expect(component.authors.length).toEqual(6);
-        expect(component.authors[0]).toEqual("Michael Winchester");
-        expect(component.authors[5]).toEqual("James Alexander Liddle");
-    });
-})
+    expect(component.authors.length).toEqual(6);
+    expect(component.authors[0]).toEqual("Michael Winchester");
+    expect(component.authors[5]).toEqual("James Alexander Liddle");
+  });
+});

--- a/angular/src/app/search/filters/filters.component.ts
+++ b/angular/src/app/search/filters/filters.component.ts
@@ -171,7 +171,7 @@ export class FiltersComponent implements OnInit, AfterViewInit {
   ) {
     this.searchFieldsListService.watchFields().subscribe((fields) => {
       this.toSortItems(fields);
-    })
+    });
   }
 
   /**
@@ -219,7 +219,6 @@ export class FiltersComponent implements OnInit, AfterViewInit {
 
   toggleExpand(expand: boolean): void {
     this.showMoreLink = !expand;
-
   }
 
   /**
@@ -231,10 +230,11 @@ export class FiltersComponent implements OnInit, AfterViewInit {
     else this.comwidth = "400px";
   }
 
-  onSearchValueChanged(){
+  onSearchValueChanged() {
     this.searchService.setQueryValue(this.searchValue, "", "");
-    this.queryStringErrorMessage =
-      this.searchQueryService.validateQueryString(this.searchValue);
+    this.queryStringErrorMessage = this.searchQueryService.validateQueryString(
+      this.searchValue
+    );
     if (!this.queryStringErrorMessage) {
       this.queryStringError = true;
     }
@@ -311,38 +311,39 @@ export class FiltersComponent implements OnInit, AfterViewInit {
     let sortItems: SelectItem[] = [];
     this.fields = [];
     let dupFound: boolean = false;
-      
+
     if (fields && fields.length > 0) {
-        for (let field of fields) {
-            if (_.includes(field.tags, "filterable")) {
-                if (field.type !== "object") {
-                    if (field.name !== "component.topic.tag") {
-                        dupFound = false;
-                        for (let item of sortItems) {
-                            if (item.label == field.label && item.value == field.name) {
-                                dupFound = true;
-                                break;
-                            }
-                        }
-                        if (!dupFound)
-                            sortItems.push({ label: field.label, value: field.name });
-                    }
+      for (let field of fields) {
+        if (_.includes(field.tags, "filterable")) {
+          if (field.type !== "object") {
+            if (field.name !== "component.topic.tag") {
+              dupFound = false;
+              for (let item of sortItems) {
+                if (item.label == field.label && item.value == field.name) {
+                  dupFound = true;
+                  break;
                 }
+              }
+              if (!dupFound)
+                sortItems.push({ label: field.label, value: field.name });
             }
-
-            if (_.includes(field.tags, "searchable")) {
-                let lValue = field.name.replace("component.", "components.");
-
-                dupFound = false;
-                for (let item of this.fields) {
-                    if (item.label == field.label && item.value == lValue) {
-                        dupFound = true;
-                        break;
-                    }
-                }
-                if (!dupFound) this.fields.push({ label: field.label, value: lValue });
-            }
+          }
         }
+
+        if (_.includes(field.tags, "searchable")) {
+          let lValue = field.name.replace("component.", "components.");
+
+          dupFound = false;
+          for (let item of this.fields) {
+            if (item.label == field.label && item.value == lValue) {
+              dupFound = true;
+              break;
+            }
+          }
+          if (!dupFound)
+            this.fields.push({ label: field.label, value: lValue });
+        }
+      }
     }
 
     this.fields = _.sortBy(this.fields, ["label", "value"]);
@@ -803,6 +804,13 @@ export class FiltersComponent implements OnInit, AfterViewInit {
 
       for (var i = 0; i < resTypeArray.length; i++) {
         resType = resTypeArray[i];
+        let resourceTypeLabel = _.startCase(_.split(resType, ":")[1]);
+
+        // Skip "Dataset" resource type
+        if (resourceTypeLabel.toLowerCase() === "dataset") {
+          continue;
+        }
+        
         this.uniqueRes.push(_.startCase(_.split(resType, ":")[1]));
         if (resourceTypesArray.indexOf(resType) < 0) {
           resourceTypes.push({


### PR DESCRIPTION
## PR: Remove "Dataset" from Type of Resource filter

### Description
Excludes "Dataset" from the Type of Resource filter options as it's a base DCAT compatibility type that all datasets inherit, making it non-useful for filtering.

### Changes
- Modified `collectResourceTypes()` method to skip "Dataset" entries
- Added case-insensitive check before adding resource types to filter options

### Code Changes
````typescript
// ...existing code...
let resourceTypeLabel = _.startCase(_.split(resType, ":")[1]);

// Skip "Dataset" resource type
if (resourceTypeLabel.toLowerCase() === "dataset") {
  continue;
}
// ...existing code...
````

### Impact
- Removes clutter from filter dropdown
- Maintains all other resource type filtering functionality
- No breaking changes